### PR TITLE
support i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,20 @@ Constants are formed by first stripping all non-word characters and then upcasin
 
 The field specified as the _enum_accessor_ must contain unique data values.
 
+## I18n
+
+ActiveHash supports i18n as ActiveModel.
+Put following code in one of your locale file (e.g. `config/locales/LANGUAGE_CODE.yml`)
+
+```yaml
+# for example, inside config/locales/ja.yml
+ja:
+  activemodel:
+    models:
+      # `Country.model_name.human` will evaluates to "国"
+      country: "国"
+```
+
 ## Contributing
 
 If you'd like to become an ActiveHash contributor, the easiest way it to fork this repo, make your changes, run the specs and submit a pull request once they pass.

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -57,11 +57,7 @@ module ActiveHash
     end
 
     if Object.const_defined?(:ActiveModel)
-      if Object.const_defined?(:I18n)
-        extend ActiveModel::Translation
-      else
-        extend ActiveModel::Naming
-      end
+      extend ActiveModel::Translation
       include ActiveModel::Conversion
     else
       def to_param

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -57,7 +57,11 @@ module ActiveHash
     end
 
     if Object.const_defined?(:ActiveModel)
-      extend ActiveModel::Naming
+      if Object.const_defined?(:I18n)
+        extend ActiveModel::Translation
+      else
+        extend ActiveModel::Naming
+      end
       include ActiveModel::Conversion
     else
       def to_param


### PR DESCRIPTION
This PR makes ActiveHash support i18n if `I18n` is available.

With this fix, model's model_name will be configurable by locale file, for example:

```
ja:
  activemodel:
    models:
      country: "国" # Country.model_name.human # => "国"
```