### PR TITLE
Support JSON serialize

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -61,6 +61,7 @@ module ActiveHash
     if Object.const_defined?(:ActiveModel)
       extend ActiveModel::Naming
       include ActiveModel::Conversion
+      include ActiveModel::Serializers::JSON
     else
       def to_param
         id.present? ? id.to_s : nil

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -1531,4 +1531,16 @@ describe ActiveHash, "Base" do
     end
   end
 
+  describe "#as_json" do
+    before do
+      Country.data = [
+        {:id => 1, :name => "US", :language => 'English'}
+      ]
+    end
+
+    it "returns a hash" do
+      country = Country.find(1)
+      expect(country.as_json.stringify_keys).to eq({"id" => 1, "name" => "US", "language" => "English"})
+    end
+  end
 end


### PR DESCRIPTION
If it use active hash with web api responses, `as_json` behavior is different between active hash's instance and active model's instance.

```
  1) ActiveHash Base #as_json returns a hash
     Failure/Error: expect(country.as_json).to eq({"id" => 1, "name" => "US", "language" => "English"})

       expected: {"id"=>1, "name"=>"US", "language"=>"English"}
            got: {"attributes"=>{"id"=>1, "name"=>"US", "language"=>"English"}}
```

We don't need `attributes` route key.

If it includes `ActiveModel::Serializers::JSON`, behavior of active hash's instance would be as same as a behavior active model's instance.

Thanks :)

---

### The reason to need this change

- When we implement web api with using active hash model and active model serializers gem, we need include `ActiveModel::Serializers::JSON` module to all active hash's models.
- It's not a little convenient for us. So I've opened this pull request.