### PR TITLE
Fix bug that .order breaks the order of original records

### DIFF
--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -12,6 +12,7 @@ module ActiveHash
       self.all_records = all_records
       self.query_hash = query_hash
       self.records_dirty = false
+      self.order_values = []
       self
     end
 
@@ -75,7 +76,14 @@ module ActiveHash
     end
 
     def reload
-      @records = filter_all_records_by_query_hash
+      filtered_records = filter_all_records_by_query_hash
+
+      if order_values.present?
+        filtered_records = filtered_records.dup if filtered_records.equal? all_records
+        order_by_args!(filtered_records)
+      end
+
+      @records = filtered_records
     end
 
     def order(*options)
@@ -83,10 +91,8 @@ module ActiveHash
       relation = where({})
       return relation if options.blank?
 
-      processed_args = preprocess_order_args(options)
       candidates = relation.dup
-
-      order_by_args!(candidates, processed_args)
+      candidates.order_values.concat preprocess_order_args(options)
 
       candidates
     end
@@ -95,12 +101,11 @@ module ActiveHash
       records.dup
     end
 
-
-    attr_reader :query_hash, :klass, :all_records, :records_dirty
+    attr_reader :query_hash, :klass, :all_records, :records_dirty, :order_values
 
     private
 
-    attr_writer :query_hash, :klass, :all_records, :records_dirty
+    attr_writer :query_hash, :klass, :all_records, :records_dirty, :order_values
 
     def records
       if @records.nil? || records_dirty
@@ -164,8 +169,8 @@ module ActiveHash
       ary.map! { |e| e.split(/\W+/) }.reverse!
     end
 
-    def order_by_args!(candidates, args)
-      args.each do |arg|
+    def order_by_args!(candidates)
+      order_values.each do |arg|
         field, dir = if arg.is_a?(Hash)
                        arg.to_a.flatten.map(&:to_sym)
                      elsif arg.is_a?(Array)

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -957,6 +957,17 @@ describe ActiveHash, "Base" do
       expect(countries.first).to eq Country.find_by(name: "Canada")
       expect(countries.second).to eq Country.find_by(name: "US")
     end
+
+    it "doesn't break the order of original records" do
+      countries = Country.order(id: :desc)
+      expect(countries.first).to eq Country.find_by(name: "Mexico")
+      expect(countries.second).to eq Country.find_by(name: "Canada")
+      expect(countries.third).to eq Country.find_by(name: "US")
+
+      expect(Country.all.first).to eq Country.find_by(name: "US")
+      expect(Country.all.second).to eq Country.find_by(name: "Canada")
+      expect(Country.all.third).to eq Country.find_by(name: "Mexico")
+    end
   end
 
   describe "#method_missing" do


### PR DESCRIPTION
This PR fixes https://github.com/zilkey/active_hash/issues/193

```ruby
class Country < ActiveHash::Base
  field :name
  field :language
  self.data = [
    {:id => 1, :name => "US", :language => 'English'},
    {:id => 2, :name => "Canada", :language => 'English'},
    {:id => 3, :name => "Mexico", :language => 'Spanish'}
  ]
end

p Country.first.name
#=> "US"
Country.order(id: :desc)
p Country.first.name
#=> "Mexico"
```

`#filter_all_records_by_query_hash` returns all_records without copy when `query_hash` is empty, so `Array#sort!` breaks the order of original records.

Thanks.