### PR TITLE
Support StrongParameters

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -12,6 +12,9 @@ module ActiveHash
   class FileTypeMismatchError < StandardError
   end
 
+  class ForbiddenAttributesError < StandardError
+  end
+
   class Base
 
     class_attribute :_data, :dirty, :default_attributes

--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -18,6 +18,12 @@ module ActiveHash
     def where(query_hash = :chain)
       return ActiveHash::Base::WhereChain.new(self) if query_hash == :chain
 
+      query_hash = sanitize_for_mass_assignment(query_hash)
+
+      unless Hash === query_hash || query_hash.nil?
+        raise ArgumentError.new "Unsupported argument type: #{query_hash.inspect} (#{query_hash.class})"
+      end
+
       self.records_dirty = true unless query_hash.nil? || query_hash.keys.empty?
       self.query_hash.merge!(query_hash || {})
       self
@@ -181,6 +187,15 @@ module ActiveHash
             a[field] <=> b[field]
           end
         end
+      end
+    end
+
+    def sanitize_for_mass_assignment(attributes)
+      if attributes.respond_to?(:permitted?)
+        raise ActiveHash::ForbiddenAttributesError unless attributes.permitted?
+        attributes.to_h
+      else
+        attributes
       end
     end
   end

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -303,6 +303,16 @@ describe ActiveHash, "Base" do
       expect(Country.where(:name => [:US, :Canada]).map(&:name)).to match_array(%w(US Canada))
     end
 
+    it "raises an ArgumentError for args ​​not Hash" do
+      expect { Country.where([[:name, :US]]) }.to raise_error(ArgumentError)
+    end
+
+    it "raises an ForbiddenAttributesError for args unauthorized parameters" do
+      params = { name: :US }
+      allow(params).to receive(:permitted?).and_return(false)
+      expect { Country.where(params) }.to raise_error(ActiveHash::ForbiddenAttributesError)
+    end
+
     it 'is chainable' do
       where_relation = Country.where(language: 'English')
 


### PR DESCRIPTION
When an allowed `ActionController::Parameters` object was given as an argument, an empty array was returned. I wanted to get the data even with the parameters.
Even if the argument is `ActionController::Parameters` object, records will be searched correctly.

```rb
# in rails
class Country < ActiveHash::Base
  self.data = [
    {:id => 1, :name => "US"},
    {:id => 2, :name => "Canada"}
  ]
 end
Country.where(name: 'US').to_a
#=> [#<Country:0x0000... @attributes={:id=>1, :name=>"US"}>]

params = ActionController::Parameters.new(name: 'US')

# before
Country.where(params.permit!).to_a
#=> []

# after
Country.where(params.permit!).to_a
#=> [#<Country:0x0000... @attributes={:id=>1, :name=>"US"}>]

Country.where(params).to_a
#=> ActiveHash::ForbiddenAttributesError
```

Tell me if insufficient testing.

And `ActiveHash::Relation#where` also raise an `ArgumentError` when an unexpected object is passed as an argument.

```rb
# before
Country.where([:id, 'US'])
#=> NoMethodError (undefined method `keys' for [:name, "US"]:Array)

# after
Country.where([:id, 'US'])
#=> ArgumentError (Unsupported argument type: [:name, "US"] (Array))
```

Thanks.