### PR TITLE
add option to disable erb parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,12 @@ Embedded ruby can be used in ActiveYaml using erb brackets `<% %>` and `<%= %>` 
   password: <%= ENV['USER_PASSWORD'] %>
 ```
 
+This can be disabled in an initializer:
+```ruby
+# config/initializers/active_yaml.rb
+ActiveYaml::Base.process_erb = false
+```
+
 ## ActiveJSON
 
 If you want to store your data in JSON files, just inherit from ActiveJSON and specify your path information:

--- a/lib/active_yaml/base.rb
+++ b/lib/active_yaml/base.rb
@@ -4,6 +4,10 @@ module ActiveYaml
 
   class Base < ActiveFile::Base
     extend ActiveFile::HashAndArrayFiles
+
+    cattr_accessor :process_erb, instance_accessor: false
+    @@process_erb = true
+
     class << self
       def load_file
         if (data = raw_data).is_a?(Array)
@@ -20,11 +24,15 @@ module ActiveYaml
       private
 if Psych::VERSION >= "4.0.0"
       def load_path(path)
-        YAML.unsafe_load(ERB.new(File.read(path)).result)
+        result = File.read(path)
+        result = ERB.new(result).result if process_erb
+        YAML.unsafe_load(result)
       end
 else
       def load_path(path)
-        YAML.load(ERB.new(File.read(path)).result)
+        result = File.read(path)
+        result = ERB.new(result).result if process_erb
+        YAML.load(result)
       end
 end
     end

--- a/spec/active_yaml/base_spec.rb
+++ b/spec/active_yaml/base_spec.rb
@@ -20,13 +20,26 @@ describe ActiveYaml::Base do
     Object.send :remove_const, :ArrayRow
     Object.send :remove_const, :City
     Object.send :remove_const, :State
+    Object.send :remove_const, :User
     Object.send :remove_const, :Empty
   end
 
   describe ".load_path" do
-    it 'can execute embedded ruby' do
-       expect(User.first.email).to match(/^user[0-9]*@email.com$/)
-       expect(User.first.password).to eq('secret')
+    context 'default' do
+      it 'can execute embedded ruby' do
+        expect(User.first.email).to match /^user[0-9]*@email.com$/
+        expect(User.first.password).to eq 'secret'
+      end
+    end
+
+    context 'erb disabled' do
+      before { ActiveYaml::Base.process_erb = false }
+      after  { ActiveYaml::Base.process_erb = true }
+
+      it 'can execute embedded ruby' do
+        expect(User.first.email).to eq '<%= "user#{rand(100)}@email.com" %>'
+        expect(User.first.password).to eq "<%= ENV['USER_PASSWORD'] %>"
+      end
     end
 
     it 'can load empty yaml' do


### PR DESCRIPTION
I needed an option to disable erb parsing. My use case is the yaml is loaded at boot time but parsed at run time. There are dynamic values that need to be set.