### PR TITLE
Records cannot be added to an empty ActiveJSON datastore

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -117,7 +117,7 @@ module ActiveHash
 
       def data=(array_of_hashes)
         mark_dirty
-        @records = nil
+        records.clear
         reset_record_index
         self._data = array_of_hashes
         if array_of_hashes
@@ -135,13 +135,12 @@ module ActiveHash
       end
 
       def insert(record)
-        @records ||= []
         record[:id] ||= next_id
         validate_unique_id(record) if dirty
         mark_dirty
 
-        add_to_record_index({ record.id.to_s => @records.length })
-        @records << record
+        add_to_record_index({ record.id.to_s => records.length })
+        records << record
       end
 
       def next_id
@@ -152,6 +151,12 @@ module ActiveHash
           max_record.id.succ
         end
       end
+
+      def records
+        @records ||= []
+      end
+
+      private :records
 
       def record_index
         @record_index ||= {}
@@ -193,7 +198,7 @@ module ActiveHash
       end
 
       def all(options = {})
-        ActiveHash::Relation.new(self, @records || [], options[:conditions] || {})
+        ActiveHash::Relation.new(self, records, options[:conditions] || {})
       end
 
       delegate :where, :find, :find_by, :find_by!, :find_by_id, :count, :pluck, :pick, :first, :last, :order, to: :all
@@ -211,7 +216,7 @@ module ActiveHash
       def delete_all
         mark_dirty
         reset_record_index
-        @records = []
+        records.clear
       end
 
       def fields(*args)

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -116,9 +116,7 @@ module ActiveHash
       end
 
       def data=(array_of_hashes)
-        mark_dirty
-        records.clear
-        reset_record_index
+        delete_all
         self._data = array_of_hashes
         if array_of_hashes
           auto_assign_fields(array_of_hashes)

--- a/lib/enum/enum.rb
+++ b/lib/enum/enum.rb
@@ -21,7 +21,7 @@ module ActiveHash
 
       def delete_all
         if @enum_accessors.present?
-          @records.each do |record|
+          records.each do |record|
             constant = constant_for(record, @enum_accessors)
             remove_const(constant) if const_defined?(constant, false)
           end

--- a/spec/active_json/base_spec.rb
+++ b/spec/active_json/base_spec.rb
@@ -46,6 +46,12 @@ describe ActiveJSON::Base do
     end
   end
 
+  describe ".create" do
+    it "does not fail when the loaded JSON was empty" do
+      Empty.create()
+    end
+  end
+
   describe ".delete_all" do
     context "when called before .all" do
       it "causes all to not load data" do

--- a/spec/active_json/base_spec.rb
+++ b/spec/active_json/base_spec.rb
@@ -23,7 +23,7 @@ describe ActiveJSON::Base do
        expect(State.first.name).to match(/^New York/)
     end
 
-    it 'can load empty yaml' do
+    it 'can load empty JSON' do
       expect(Empty.first).to be_nil
     end
   end


### PR DESCRIPTION
Here's the simplest way to reproduce the error:

```rb
# test.rb

require "active_hash"

class Test < ActiveJSON::Base; end

Test.create()
```

```sh
$ echo '[]' > tests.json
$ ruby test.rb
Traceback (most recent call last):
        3: from test.rb:7:in `<main>'
        2: from /Users/david-stosik/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/active_hash-3.0.0/lib/active_hash/base.rb:174:in `create'
        1: from /Users/david-stosik/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/active_hash-3.0.0/lib/active_hash/base.rb:497:in `save'
/Users/david-stosik/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/active_hash-3.0.0/lib/active_hash/base.rb:135:in `insert': undefined method `length' for nil:NilClass (NoMethodError)
```

In some scenarios, `@records` can be `nil` when checking its `length` and appending a new record.

This PR adds a test case that reproduces the error above, and fixes it.

My first approach was to simply replace [`@records = nil`](https://github.com/zilkey/active_hash/blob/94113220327e6bb97135062e07f0d7d3429a9def/lib/active_hash/base.rb#L70) with `@records = []`, but then I figured out I could do better and improve the code base a bit, avoiding in the process duplication of code such as `@records || []`.

All specs still pass.

Please let me know what you think.