### PR TITLE
Return a chainable Relation when using .not(id: …)

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -30,10 +30,9 @@ module ActiveHash
           ids = @scope.pluck(:id) - Array.wrap(options.delete(:id) || options.delete("id"))
           candidates = ids.map { |id| @scope.find_by_id(id) }.compact
         end
-        return candidates if options.blank?
 
         filtered_records = (candidates || @records || []).reject do |record|
-          match_options?(record, options)
+          options.present? && match_options?(record, options)
         end
         
         ActiveHash::Relation.new(@scope.klass, filtered_records, {})

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -383,6 +383,10 @@ describe ActiveHash, "Base" do
       record.last.name.should == 'Mexico'
     end
 
+    it "returns a chainable relation even if id is given" do
+      Country.where.not(id: 1).class.should == ActiveHash::Relation
+    end
+
     it "returns all records when id is nil" do
       expect(Country.where.not(:id => nil)).to eq Country.all
     end


### PR DESCRIPTION
This PR fixes the inconsistent return value from using `.where.not(id: ..)`. Right now, if `id:` is the only option given in a `not` call, you'll get an `Array` of objects back instead of a chainable `ActiveHash::Relation`. The inconsistent return values is very confusing and makes it impossible to inject eg. modules into `ActiveHash::Relation` in a consistent way (useful for eg. adding pagination and using `ActiveHash::Relation` as a mix'n'match with `ActiveRecord::Relation`.

Before:
```ruby
SomeModel.where(id: [1, 2, 3]).class
=> ActiveHash::Relation 

SomeModel.where.not(id: [1, 2, 3], other_value: true).class
=> ActiveHash::Relation

SomeModel.where.not(id: [1, 2, 3], other_value: true).where(something: true).class
=> ActiveHash::Relation

SomeModel.where.not(id: [1, 2, 3]).class
=> Array # WTF?

SomeModel.where.not(id: [1, 2, 3]).where(something: true).class
=> NoMethodError - undefined method #where on Array!
```

After:
```ruby
...

SomeModel.where.not(id: [1, 2, 3]).class
=> ActiveHash::Relation

SomeModel.where.not(id: [1, 2, 3]).where(something: true).class
=> ActiveHash::Relation
```

I'd think the performance overhead from not doing the early return is negligible unless you have millions of records, in which case you should probably not use `ActiveHash` in the first place.