### PR TITLE
Implement `ActiveHash::Relation#ids`

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -196,7 +196,7 @@ module ActiveHash
         ActiveHash::Relation.new(self, @records || [], options[:conditions] || {})
       end
 
-      delegate :where, :find, :find_by, :find_by!, :find_by_id, :count, :pluck, :pick, :first, :last, :order, to: :all
+      delegate :where, :find, :find_by, :find_by!, :find_by_id, :count, :pluck, :ids, :pick, :first, :last, :order, to: :all
 
       def transaction
         yield

--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -72,6 +72,10 @@ module ActiveHash
       column_names.map { |column_name| all.map(&column_name.to_sym) }.inject(&:zip)
     end
 
+    def ids
+      pluck(:id)
+    end
+
     def pick(*column_names)
       pluck(*column_names).first
     end

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -537,6 +537,19 @@ describe ActiveHash, "Base" do
     end
   end
 
+  describe '.ids' do
+    before do
+      Country.data = [
+        {:id => 1, :name => "US"},
+        {:id => 2, :name => "Canada"}
+      ]
+    end
+
+    it "returns an Array of id attributes" do
+      expect(Country.ids).to match_array([1,2])
+    end
+  end
+
   describe ".pick" do
     before do
       Country.data = [


### PR DESCRIPTION
Pluck all the `id` from the `ActiveHash::Relation` for `ActiveRecord::Relation#ids` compatibility.
