### PR TITLE
Add thread safety to ActiveFile

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -145,13 +145,18 @@ module ActiveHash
       end
 
       def next_id
-        max_record = all.max { |a, b| a.id <=> b.id }
+        max_record = all_in_process.max { |a, b| a.id <=> b.id }
         if max_record.nil?
           1
         elsif max_record.id.is_a?(Numeric)
           max_record.id.succ
         end
       end
+
+      def all_in_process
+        all
+      end
+      private :all_in_process
 
       def record_index
         @record_index ||= {}

--- a/spec/active_yaml/base_spec.rb
+++ b/spec/active_yaml/base_spec.rb
@@ -32,6 +32,12 @@ describe ActiveYaml::Base do
     it 'can load empty yaml' do
       expect(Empty.first).to be_nil
     end
+
+    it 'is thread-safe' do
+      (1..5).map do
+        Thread.new { expect(City.count).to eq(2) }
+      end.each(&:join)
+    end
   end
 
   describe ".all" do


### PR DESCRIPTION
ActiveFile is not thread-safe, which results in the following: if the very first request to ActiveFile goes simultaneously from even two threads, the first one is going to return as if the data was empty. The second request will immediately fix that, but that unlucky thread will receive a bad value. It may store it in the database or memoize it, which will result in further problem escalation.

We can't just synchronise it, because we check the variable very far from reload. While we must synchronise, it's not enough. We have to flag it as 'done' only after it's loaded.

Another problem is that we touch `all` in process of reloading, which will check `data_loaded` flag and try to reload again. To counter that, I come out with a method that won't trigger reload, to use it in methods that work during reload.

Resolves #159.