### PR TITLE
Speed up automatic id definition

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -136,17 +136,21 @@ module ActiveHash
 
       def insert(record)
         @records ||= []
-        @max_id ||= 0
-        if record[:id] && record[:id].is_a?(Numeric)
-          @max_id = [@max_id, record[:id]].max
-        else
-          record[:id] ||= (@max_id = @max_id.succ)
-        end
+        set_id(record)
         validate_unique_id(record) if dirty
         mark_dirty
 
         add_to_record_index({ record.id.to_s => @records.length })
         @records << record
+      end
+
+      def set_id(record)
+        # sets record[:id] to @max_id+1 if it doesn't exist
+        if record[:id] && record[:id].is_a?(Numeric)
+          @max_id = [@max_id || 0, record[:id].ceil].max
+        else
+          record[:id] ||= (@max_id = @max_id.to_i.succ)
+        end
       end
 
       def record_index

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -136,21 +136,17 @@ module ActiveHash
 
       def insert(record)
         @records ||= []
-        record[:id] ||= next_id
+        @max_id ||= 0
+        if record[:id] && record[:id].is_a?(Numeric)
+          @max_id = [@max_id, record[:id]].max
+        else
+          record[:id] ||= (@max_id = @max_id.succ)
+        end
         validate_unique_id(record) if dirty
         mark_dirty
 
         add_to_record_index({ record.id.to_s => @records.length })
         @records << record
-      end
-
-      def next_id
-        max_record = all.max { |a, b| a.id <=> b.id }
-        if max_record.nil?
-          1
-        elsif max_record.id.is_a?(Numeric)
-          max_record.id.succ
-        end
       end
 
       def record_index

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -1389,6 +1389,37 @@ describe ActiveHash, "Base" do
       expect(country2.id).to eq(1)
     end
 
+
+    it "does not blow up with negative integer" do
+      country1 = Country.new :id => -5, :name => "foo"
+      country1.save
+      expect(country1.id).to eq(-5)
+
+      country2 = Country.new :name => "foo"
+      country2.save
+      expect(country2.id).to eq(1)
+    end
+
+    it "does not blow up with float" do
+      country1 = Country.new :id => 0.1, :name => "foo"
+      country1.save
+      expect(country1.id).to eq(0.1)
+
+      country2 = Country.new :name => "foo"
+      country2.save
+      expect(country2.id).to eq(2)
+    end
+
+    it "does not blow up with negative float" do
+      country1 = Country.new :id => -0.1, :name => "foo"
+      country1.save
+      expect(country1.id).to eq(-0.1)
+
+      country2 = Country.new :name => "foo"
+      country2.save
+      expect(country2.id).to eq(1)
+    end
+
     it "adds the new object to the data collection" do
       expect(Country.all).to be_empty
       country = Country.create! :id => 1, :name => "foo"

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -1386,7 +1386,7 @@ describe ActiveHash, "Base" do
 
       country2 = Country.new :name => "foo"
       country2.save
-      expect(country2.id).to be_nil
+      expect(country2.id).to eq(1)
     end
 
     it "adds the new object to the data collection" do


### PR DESCRIPTION
In our use case, we have a large amount of data with no id. It generates a performance issue due to the comparison of all the ids to find the maximum.

To fix it, we store the current maximum, and only perform the comparison to this value during the insertion.