### PR TITLE
Defines the getter method for the collection_singular_ids.

### DIFF
--- a/lib/associations/associations.rb
+++ b/lib/associations/associations.rb
@@ -90,7 +90,6 @@ module ActiveHash
 
     module Methods
       def has_many(association_id, options = {})
-
         define_method(association_id) do
           options = {
             :class_name => association_id.to_s.classify,
@@ -109,6 +108,9 @@ module ActiveHash
           else
             klass.where(foreign_key => primary_key_value)
           end
+        end
+        define_method("#{association_id.to_s.underscore.singularize}_ids") do
+          public_send(association_id).map(&:id)
         end
       end
 

--- a/spec/associations/active_record_extensions_spec.rb
+++ b/spec/associations/active_record_extensions_spec.rb
@@ -75,6 +75,11 @@ unless SKIP_ACTIVE_RECORD
             expect(author.books).to eq([@book_1, @book_2])
           end
 
+          it "should find the correct record ids" do
+            author = Author.create :id => 1
+            expect(author.book_ids).to eq([@book_1.id, @book_2.id])
+          end
+
           it "return a scope so that we can apply further scopes" do
             author = Author.create :id => 1
             expect(author.books.published).to eq([@book_1])
@@ -95,6 +100,11 @@ unless SKIP_ACTIVE_RECORD
             expect(author.books).to eq([@book_2, @book_3])
           end
 
+          it "should find the correct record ids" do
+            author = Author.create :id => 1, :book_identifier => 2
+            expect(author.book_ids).to eq([@book_2.id, @book_3.id])
+          end
+
           it "return a scope so that we can apply further scopes" do
             author = Author.create :id => 1, :book_identifier => 2
             expect(author.books.published).to eq([@book_3])
@@ -112,6 +122,11 @@ unless SKIP_ACTIVE_RECORD
           it "should find the correct records" do
             author = Author.create :id => 1
             expect(author.books).to eq([@book_1, @book_2])
+          end
+
+          it "should find the correct record ids" do
+            author = Author.create :id => 1
+            expect(author.book_ids).to eq([@book_1.id, @book_2.id])
           end
 
           it "return a scope so that we can apply further scopes" do


### PR DESCRIPTION
Defines the getter method for the collection_singular_ids. 

ex:
```rb
Author.has_many :books

Book.create! :author_id => 1
Book.create! :author_id => 1
Book.create! :author_id => 3

author.book_ids => [1,2]
```

Resolve this issue  
https://github.com/zilkey/active_hash/issues/236