### PR TITLE
Use double splat operator in belongs_to call to super

### DIFF
--- a/lib/associations/associations.rb
+++ b/lib/associations/associations.rb
@@ -16,7 +16,7 @@ module ActiveHash
         if klass && klass < ActiveHash::Base
           belongs_to_active_hash(name, options)
         else
-          super
+          super(name, **options)
         end
       end
 


### PR DESCRIPTION
I ran across this in a project I'm working on and found out other people were having the same problem: Issue #225.

`super` was calling the following method in ActiveRecord:
```ruby
def belongs_to(name, scope = nil, **options)
  reflection = Builder::BelongsTo.build(self, name, scope, options)
  Reflection.add_reflection self, name, reflection
end
```

`options` was getting substituted into `scope` which was causing the bug.
There might be a better fix for this (Using [ruby2_keywords](https://github.com/ruby/ruby2_keywords)?) so I can look over the code just in case, but this fixes the issue for me.