### PR TITLE
Fix unexpected `RecordNotFound` exception when pass a block to `ActiveFile::Base.find`

### DIFF
--- a/lib/active_file/base.rb
+++ b/lib/active_file/base.rb
@@ -47,9 +47,9 @@ module ActiveFile
       protected :actual_root_path
 
       [:find, :find_by_id, :all, :where, :method_missing].each do |method|
-        define_method(method) do |*args|
+        define_method(method) do |*args, &block|
           reload unless data_loaded
-          return super(*args)
+          return super(*args, &block)
         end
       end
 


### PR DESCRIPTION
## Problem

I have occurred unexpected `ActiveHash::RecordNotFound` exception when pass a block to `ActiveFile::Base.find`.

## Minimum reproduction code

``` ruby
class Country < ActiveYaml::Base
  set_filename "sample"
end
```

``` yaml
- id: 1
  name: US
- id: 2
  name: Canada
- id: 3
  name: Mexico
```

``` ruby
# Actual
Çountry.find { |c| c.name == "US" } # => ActiveHash::RecordNotFound

# Expected
Çountry.find { |c| c.name == "US" } # => <Country:0x000000010686c7f0 @attributes={:id=>1, :name=>"US"}>
```

## This PR's changes

I fixed to pass a block to `super` method in `ActiveFile::Base.find`