### PR TITLE
remove wwtd

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source "http://rubygems.org/"
 gemspec
 
 gem 'rspec', '~> 3.9'
-gem 'wwtd'
 gem 'rake'
 gem 'test-unit'
 gem 'json'

--- a/README.md
+++ b/README.md
@@ -624,10 +624,6 @@ To make users' lives easier, please maintain support for:
   * Ruby 2.4
   * ActiveRecord/ActiveSupport from 5.0 through edge
 
-To that end, run specs against all rubies before committing:
-
-    wwtd
-
 Once appraisal passes in all supported rubies, follow these steps to release a new version of active_hash:
 
   * update the changelog with a brief summary of the changes that are included in the release

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,9 @@
 require 'bundler/setup'
 require 'bundler/gem_tasks'
-require 'wwtd/tasks'
 
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = 'spec/**/*_spec.rb'
 end
 
-task :default => :wwtd
+task :default => :spec

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -2,7 +2,6 @@ source 'http://rubygems.org/'
 
 gem 'activerecord', '~> 5.0.0'
 gem 'rspec', '~> 3.9'
-gem 'wwtd'
 gem 'rake', '~> 10.0'
 gem 'json'
 gem 'test-unit'

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -2,7 +2,6 @@ source 'http://rubygems.org/'
 
 gem 'activerecord', '~> 5.1.0'
 gem 'rspec', '~> 3.9'
-gem 'wwtd'
 gem 'rake', '~> 10.0'
 gem 'json'
 gem 'test-unit'

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -2,7 +2,6 @@ source 'http://rubygems.org/'
 
 gem 'activerecord', '~> 5.2.0'
 gem 'rspec', '~> 3.9'
-gem 'wwtd'
 gem 'rake', '~> 10.0'
 gem 'json'
 gem 'test-unit'

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -2,7 +2,6 @@ source 'http://rubygems.org/'
 
 gem 'activerecord', '~> 6.0.0'
 gem 'rspec', '~> 3.9'
-gem 'wwtd'
 gem 'rake', '~> 10.0'
 gem 'json'
 gem 'test-unit'

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -2,7 +2,6 @@ source 'http://rubygems.org/'
 
 gem 'activerecord', '~> 6.1.0'
 gem 'rspec', '~> 3.9'
-gem 'wwtd'
 gem 'rake', '~> 13.0'
 gem 'json'
 gem 'test-unit'

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -2,7 +2,6 @@ source 'http://rubygems.org/'
 
 gem 'activerecord', '~> 7.0.0'
 gem 'rspec', '~> 3.9'
-gem 'wwtd'
 gem 'rake', '~> 13.0'
 gem 'json'
 gem 'test-unit'


### PR DESCRIPTION
## Before

Running `rake` locally fails. It links to `wwtd` (What Would Travis Do). Since we have moved all of our configuration data to github actions, there is no `.travis.yml` file for `wwtd` to work. So it makes sense that it would fail.

I really like `wwtd`, so I am sad to say good bye to it. But it no longer works and linking to it is causing developers to not be able to run the specs with a simple `rake`.

```
[master] active_hash $ rake
START
bundle install --quiet
bundle exec rake
rake aborted!
Already running WWTD
/Users/kbrock/.gem/ruby/3.0.3/gems/wwtd-1.4.1/lib/wwtd/cli.rb:53:in `protect_against_nested_runs'
/Users/kbrock/.gem/ruby/3.0.3/gems/wwtd-1.4.1/lib/wwtd/cli.rb:16:in `run'
...
/Users/kbrock/.gem/ruby/3.0.3/bin/bundle:23:in `<main>'
Tasks: TOP => default => wwtd
(See full trace by running task with --trace)
FAILURE
rm -rf .bundle

Failed:
bundle exec rake
```
## After

Running `rake` now runs the specs again, albeit not on the full gambit of ruby and rails versions.

```
[wwtd] active_hash $ rake
/Users/kbrock/.rubies/ruby-3.0.3/bin/ruby -I/Users/kbrock/.gem/ruby/3.0.3/gems/rspec-core-3.12.1/lib:/Users/kbrock/.gem/ruby/3.0.3/gems/rspec-support-3.12.0/lib /Users/kbrock/.gem/ruby/3.0.3/gems/rspec-core-3.12.1/exe/rspec --pattern spec/\*\*/\*_spec.rb
...........................................................................................................................................................................................................................................................................................................................................................

Finished in 0.64132 seconds (files took 0.60096 seconds to load)
347 examples, 0 failures
```