### PR TITLE
Avoid ActiveRecordExtensions affects AR's belongs_to method.

### DIFF
--- a/lib/associations/associations.rb
+++ b/lib/associations/associations.rb
@@ -16,7 +16,7 @@ module ActiveHash
         if klass && klass < ActiveHash::Base
           belongs_to_active_hash(name, options)
         else
-          super(name, **options)
+          super
         end
       end
 

--- a/spec/associations/active_record_extensions_spec.rb
+++ b/spec/associations/active_record_extensions_spec.rb
@@ -151,15 +151,17 @@ unless SKIP_ACTIVE_RECORD
 
         if ActiveRecord::VERSION::MAJOR > 3
           it "doesn't interfere with AR's procs in belongs_to methods" do
-            School.belongs_to :country, lambda { where() }
+            School.belongs_to :country, lambda { select(:id) }
             school = School.new
-            country = Country.create!
+            country = Country.create!(id: 1, name: 'Japan')
             school.country = country
             expect(school.country).to eq(country)
             expect(school.country_id).to eq(country.id)
+            expect(school.country.attributes).to eq({ 'id' => 1, 'name' => 'Japan' })
             school.save!
             school.reload
-            expect(school.reload.country_id).to eq(country.id)
+            expect(school.country_id).to eq(country.id)
+            expect(school.country.attributes).to eq({ 'id' => 1 })
           end
         end
 

--- a/spec/associations/active_record_extensions_spec.rb
+++ b/spec/associations/active_record_extensions_spec.rb
@@ -151,17 +151,22 @@ unless SKIP_ACTIVE_RECORD
 
         if ActiveRecord::VERSION::MAJOR > 3
           it "doesn't interfere with AR's procs in belongs_to methods" do
-            School.belongs_to :country, lambda { select(:id) }
+            School.belongs_to :country, lambda { where(name: 'Japan') }
             school = School.new
             country = Country.create!(id: 1, name: 'Japan')
             school.country = country
             expect(school.country).to eq(country)
             expect(school.country_id).to eq(country.id)
-            expect(school.country.attributes).to eq({ 'id' => 1, 'name' => 'Japan' })
+            expect(school.country).to eq(country)
             school.save!
             school.reload
             expect(school.country_id).to eq(country.id)
-            expect(school.country.attributes).to eq({ 'id' => 1 })
+            expect(school.country).to eq(country)
+
+            country.update!(name: 'JAPAN')
+            school.reload
+            expect(school.country_id).to eq(country.id)
+            expect(school.country).to eq(nil)
           end
         end
 


### PR DESCRIPTION
# Background
ActiveRecord#belongs_to accepts these args. [ref](https://github.com/rails/rails/blob/789a3648f37220a8419b43bc67ef8d81c80bdb1a/activerecord/lib/active_record/associations.rb#L1791-L1794)

```
        def belongs_to(name, scope = nil, **options)
          reflection = Builder::BelongsTo.build(self, name, scope, options)
          Reflection.add_reflection self, name, reflection
        end
```

But , ActiveRecordExtensions drops `scope` arguments.

https://github.com/active-hash/active_hash/blob/b11cb2e6151c6ac67d15d659fb2f2a931061bffa/lib/associations/associations.rb#L6-L21

# Changes
In this PR, by calling super with no arguments, all arguments including scope are passed to super.

