### PR TITLE
isolate tests with temporary classes

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,3 +13,13 @@ require 'active_record' unless SKIP_ACTIVE_RECORD
 Dir["spec/support/**/*.rb"].each { |f|
   require File.expand_path(f)
 }
+
+RSpec.configure do |config|
+  config.after(:each) do
+    # To isolate tests with temporary classes.
+    # ref: https://groups.google.com/g/rspec/c/7CQq0ABS3yQ
+    if ActiveRecord::VERSION::MAJOR < 7
+      ActiveSupport::Dependencies::Reference.clear!
+    end
+  end
+end


### PR DESCRIPTION
# background
ActiveRecord [v5](https://github.com/rails/rails/blob/v5.2.8.1/activesupport/lib/active_support/dependencies.rb#L612-L620) and [v6](https://github.com/rails/rails/blob/v6.1.6.1/activesupport/lib/active_support/dependencies.rb#L666-L674) uses [ActiveSupport::Dependencies#constantize](https://github.com/rails/rails/blob/dc1242fd5a4d91e63846ab552a07e19ebf8716ac/activesupport/lib/active_support/dependencies.rb#L666), [ActiveSupport::Dependencies#saef_constantize](https://github.com/rails/rails/blob/dc1242fd5a4d91e63846ab552a07e19ebf8716ac/activesupport/lib/active_support/dependencies.rb#L672) which uses cached constantize results.

According to [this](https://groups.google.com/g/rspec/c/7CQq0ABS3yQ), the above behavior is bug and fixed in ActiveRecord [v7](https://github.com/rails/rails/commit/14d4edd7c3b06e82e1fcef54fa0b4453315c35fd)

# changes
If the tests run with ActiveRecord v5 and v6, clear the cache in the before hook of all test cases to avoid ActiveRecord edge case bug.

# note

Pulled out of https://github.com/active-hash/active_hash/pull/255