### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/active_file/hash_and_array_files.rb
+++ b/lib/active_file/hash_and_array_files.rb
@@ -13,7 +13,7 @@ module ActiveFile
       loaded_files = full_paths.collect { |path| load_path(path) }
 
       if loaded_files.all?{ |file_data| file_data.is_a?(Array) }
-        loaded_files.sum
+        loaded_files.sum([])
       elsif loaded_files.all?{ |file_data| file_data.is_a?(Hash) }
         loaded_files.inject({}) { |hash, file_data| hash.merge(file_data) }
       else

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -487,7 +487,11 @@ module ActiveHash
         when new_record?
           "#{self.class.cache_key}/new"
         when timestamp = self[:updated_at]
-          "#{self.class.cache_key}/#{id}-#{timestamp.to_s(:number)}"
+          if ActiveSupport::VERSION::MAJOR < 7
+            "#{self.class.cache_key}/#{id}-#{timestamp.to_s(:number)}"
+          else
+            "#{self.class.cache_key}/#{id}-#{timestamp.to_fs(:number)}"
+          end
         else
           "#{self.class.cache_key}/#{id}"
       end

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -1314,7 +1314,11 @@ describe ActiveHash, "Base" do
         {:id => 1, :name => "foo", :updated_at => timestamp}
       ]
 
-      expect(Country.first.cache_key).to eq("countries/1-#{timestamp.to_s(:number)}")
+      if ActiveSupport::VERSION::MAJOR < 7
+        expect(Country.first.cache_key).to eq("countries/1-#{timestamp.to_s(:number)}")
+      else
+        expect(Country.first.cache_key).to eq("countries/1-#{timestamp.to_fs(:number)}")
+      end
     end
 
     it 'should use "new" instead of the id for a new record' do


### PR DESCRIPTION
I fixed two deprecation warnings below. 

* `DEPRECATION WARNING: Rails 7.0 has deprecated Enumerable.sum in favor of Ruby's native implementation available since 2.4. Sum of non-numeric elements requires an initial argument.
`
* `DEPRECATION WARNING: Time#to_s(:number) is deprecated. Please use Time#to_fs(:number) instead.`