### PR TITLE
Remove redundant ActiveRecord version check

### DIFF
--- a/spec/associations/active_record_extensions_spec.rb
+++ b/spec/associations/active_record_extensions_spec.rb
@@ -149,18 +149,16 @@ unless SKIP_ACTIVE_RECORD
 
       describe "#belongs_to" do
 
-        if ActiveRecord::VERSION::MAJOR > 3
-          it "doesn't interfere with AR's procs in belongs_to methods" do
-            School.belongs_to :country, lambda { where() }
-            school = School.new
-            country = Country.create!
-            school.country = country
-            expect(school.country).to eq(country)
-            expect(school.country_id).to eq(country.id)
-            school.save!
-            school.reload
-            expect(school.reload.country_id).to eq(country.id)
-          end
+        it "doesn't interfere with AR's procs in belongs_to methods" do
+          School.belongs_to :country, lambda { where() }
+          school = School.new
+          country = Country.create!
+          school.country = country
+          expect(school.country).to eq(country)
+          expect(school.country_id).to eq(country.id)
+          school.save!
+          school.reload
+          expect(school.reload.country_id).to eq(country.id)
         end
 
         it "doesn't interfere w/ ActiveRecord's polymorphism" do


### PR DESCRIPTION
ActiveHash now supports ActiveRecord >= 5.
https://github.com/active-hash/active_hash/blob/18d242f553d0045f84ae99cca88864303480dc99/active_hash.gemspec#L47