### PR TITLE
Show example using regex in where query

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Country.find_by_id 1           # => find the first object that matches the id
 Country.find_by(name: 'US')    # => returns the first country object with specified argument
 Country.find_by!(name: 'US')   # => same as find_by, but raise exception when not found
 Country.where(name: 'US')      # => returns all records with name: 'US'
+Country.where(name: /U/)       # => returns all records where the name matches the regex /U/
 Country.where.not(name: 'US')  # => returns all records without name: 'US'
 Country.order(name: :desc)     # => returns all records ordered by name attribute in DESC order
 ```


### PR DESCRIPTION
Update README to show example of using a regex with the `.where` method