### PR TITLE
docs: Remove the string 'F'

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ ActiveHash also ships with:
 
   * ActiveFile: a base class that you can use to create file data sources
   * ActiveYaml: a base class that will turn YAML into a hash and load the data into an ActiveHash object
-F
+
 ## !!! Important notice !!!
 We have changed returned value to chainable by v3.0.0. It's not just an `Array` instance anymore.
 If it breaks your application, please report us on [issues](https://github.com/active-hash/active_hash/issues), and use v2.x.x as following..


### PR DESCRIPTION
Hi.

In this PR, I'm removing a string that might be unnecessary for the README.
I guess this 'F' is just some kind of typo ... is it right ?

redo of #221