### PR TITLE
Relation: Make `where` return a fresh relation to avoid leaking scopes

### DIFF
--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -236,6 +236,14 @@ describe ActiveHash, "Base" do
       Country.where(:language => 'English').all? { |country| expect(country).to be_kind_of(Country) }
     end
 
+    it "doesn't affect the original" do
+      countries = Country.where(:language => 'English')
+
+      expect(countries.size).to eq 2
+      expect(countries.where(name: "US").size).to eq 1
+      expect(countries.size).to eq 2
+    end
+
     it "populates the data correctly" do
       records = Country.where(:language => 'English')
       expect(records.first.id).to eq(1)


### PR DESCRIPTION
This PR fixes issue #257 where scopes are leaking. The issue can lead to wildly unexpected behavior.

Previously calling `.where(..)` would mutate the original relation.

#### Before this change
```ruby
expect(countries.size).to eq 2
expect(countries.where(name: "US").size).to eq 1
expect(countries.size).to eq 2 # ❌ Fails as previous line mutated the `countries` object
```

#### After this change
```ruby
expect(countries.size).to eq 2
expect(countries.where(name: "US").size).to eq 1
expect(countries.size).to eq 2 # ✅ Passes as the previous line returned a new relation keeping the original
```

The change also makes the "dirty tracking" in `Relation` unnecessary as Relations are immutable. 