### PR TITLE
Bugfix: Ensure that using `id: [..]` as condition returns unique records

### DIFF
--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -10,7 +10,7 @@ module ActiveHash
     def initialize(klass, all_records, query_hash = nil)
       self.klass = klass
       self.all_records = all_records
-      self.query_hash = query_hash
+      self.query_hash = query_hash.deep_symbolize_keys
       self.records_dirty = false
       self
     end
@@ -130,8 +130,8 @@ module ActiveHash
       return all_records if query_hash.blank?
 
       # use index if searching by id
-      if query_hash.key?(:id) || query_hash.key?("id")
-        ids = (query_hash.delete(:id) || query_hash.delete("id"))
+      if query_hash.key?(:id)
+        ids = query_hash.delete(:id)
         ids = range_to_array(ids) if ids.is_a?(Range)
         candidates = Array.wrap(ids).map { |id| klass.find_by_id(id) }.compact
       end

--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -133,7 +133,7 @@ module ActiveHash
       if query_hash.key?(:id)
         ids = query_hash.delete(:id)
         ids = range_to_array(ids) if ids.is_a?(Range)
-        candidates = Array.wrap(ids).map { |id| klass.find_by_id(id) }.compact
+        candidates = Array.wrap(ids).uniq.map { |id| klass.find_by_id(id) }.compact
       end
 
       return candidates if query_hash.blank?

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -282,7 +282,7 @@ describe ActiveHash, "Base" do
     end
 
     it "returns multiple records for multiple ids" do
-      expect(Country.where(:id => %w(1 2)).map(&:id)).to match_array([1,2])
+      expect(Country.where(:id => %w(1 1 2)).map(&:id)).to match_array([1,2])
     end
 
     it "returns multiple records for range argument" do


### PR DESCRIPTION
This PR fixes an issue where only unique records will be returned when using `where(id: ..)`. Previously, if the same ID was provided multiple times in the `id` condition, it would be returned multiple times.

This PR fixes the issue and now mimics the way ActiveRecord work. It also streamlines so that `query_hash` always has symbols as keys. We can use `deep_symbolize_keys` for this as there's already a dependency on ActiveSupport.

### Before
```ruby
Country.where(id: [1, 2, 1])
# => 3 records; the Country with ID=1 is returned twice
```

### After
```ruby
Country.where(id: [1, 2, 1])
# => 2 records as expected
```