### PR TITLE
Refactor `Relation` and conditions to fix mutating scopes issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,11 +211,11 @@ Country#name=       # => sets the name
 The ActiveHash::Base.all method functions like an in-memory data store. You can save your records as ActiveHash::Relation object by using standard ActiveRecord create and save methods:
 ```ruby
 Country.all
-=> #<ActiveHash::Relation:0x00007f861e043bb0 @klass=Country, @all_records=[], @query_hash={}, @records_dirty=false>
+=> #<ActiveHash::Relation:0x00007f861e043bb0 @klass=Country, @all_records=[], @conditions=[..], @records_dirty=false>
 Country.create
 => #<Country:0x00007f861b7abce8 @attributes={:id=>1}>
 Country.all
-=> #<ActiveHash::Relation:0x00007f861b7b3628 @klass=Country, @all_records=[#<Country:0x00007f861b7abce8 @attributes={:id=>1}>], @query_hash={}, @records_dirty=false>
+=> #<ActiveHash::Relation:0x00007f861b7b3628 @klass=Country, @all_records=[#<Country:0x00007f861b7abce8 @attributes={:id=>1}>], @conditions=[..], @records_dirty=false>
 country = Country.new
 => #<Country:0x00007f861e059938 @attributes={}>
 country.new_record?
@@ -225,7 +225,7 @@ country.save
 country.new_record?
 # => false
 Country.all
-=> #<ActiveHash::Relation:0x00007f861e0ca610 @klass=Country, @all_records=[#<Country:0x00007f861b7abce8 @attributes={:id=>1}>, #<Country:0x00007f861e059938 @attributes={:id=>2}>], @query_hash={}, @records_dirty=false>
+=> #<ActiveHash::Relation:0x00007f861e0ca610 @klass=Country, @all_records=[#<Country:0x00007f861b7abce8 @attributes={:id=>1}>, #<Country:0x00007f861e059938 @attributes={:id=>2}>], @conditions=[..], @records_dirty=false>
 ```
 Notice that when adding records to the collection, it will auto-increment the id for you by default.  If you use string ids, it will not auto-increment the id.  Available methods are:
 ```

--- a/lib/active_hash.rb
+++ b/lib/active_hash.rb
@@ -13,6 +13,8 @@ end
 
 require 'active_hash/base'
 require 'active_hash/relation'
+require 'active_hash/condition'
+require 'active_hash/conditions'
 require 'active_file/multiple_files'
 require 'active_file/hash_and_array_files'
 require 'active_file/base'

--- a/lib/active_hash/condition.rb
+++ b/lib/active_hash/condition.rb
@@ -32,7 +32,7 @@ class ActiveHash::Relation::Condition
 
   def matches_value?(value, comparison)
     return comparison.any? { |v| matches_value?(value, v) } if comparison.is_a?(Array)
-    return comparison.include?(value) if comparison.is_a?(Range)
+    return comparison.cover?(value) if comparison.is_a?(Range)
     return comparison.match?(value) if comparison.is_a?(Regexp)
 
     normalize(value) == normalize(comparison)

--- a/lib/active_hash/condition.rb
+++ b/lib/active_hash/condition.rb
@@ -1,0 +1,44 @@
+class ActiveHash::Relation::Condition
+  attr_reader :constraints, :inverted
+
+  def initialize(constraints)
+    @constraints = constraints
+    @inverted = false
+  end
+
+  def invert!
+    @inverted = !inverted
+
+    self
+  end
+
+  def matches?(record)
+    match = begin
+      return true unless constraints
+
+      expectation_method = inverted ? :any? : :all?
+
+      constraints.send(expectation_method) do |attribute, expected|
+        value = record.public_send(attribute)
+
+        matches_value?(value, expected)
+      end
+    end
+
+    inverted ? !match : match
+  end
+
+  private
+
+  def matches_value?(value, comparison)
+    return comparison.any? { |v| matches_value?(value, v) } if comparison.is_a?(Array)
+    return comparison.include?(value) if comparison.is_a?(Range)
+    return comparison.match?(value) if comparison.is_a?(Regexp)
+
+    normalize(value) == normalize(comparison)
+  end
+
+  def normalize(value)
+    value.respond_to?(:to_s) ? value.to_s : value
+  end
+end

--- a/lib/active_hash/conditions.rb
+++ b/lib/active_hash/conditions.rb
@@ -1,7 +1,7 @@
 class ActiveHash::Relation::Conditions
   attr_reader :conditions
 
-  delegate_missing_to :conditions
+  delegate :<<, :map, to: :conditions
 
   def initialize(conditions = [])
     @conditions = conditions

--- a/lib/active_hash/conditions.rb
+++ b/lib/active_hash/conditions.rb
@@ -1,0 +1,21 @@
+class ActiveHash::Relation::Conditions
+  attr_reader :conditions
+
+  delegate_missing_to :conditions
+
+  def initialize(conditions = [])
+    @conditions = conditions
+  end
+
+  def matches?(record)
+    conditions.all? do |condition|
+      condition.matches?(record)
+    end
+  end
+
+  def self.wrap(conditions)
+    return conditions if conditions.is_a?(self)
+
+    new(conditions)
+  end
+end

--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -48,6 +48,15 @@ module ActiveHash
       self
     end
 
+    def invert_where
+      spawn.invert_where!
+    end
+
+    def invert_where!
+      conditions.map(&:invert!)
+      self
+    end
+
     def spawn
       self.class.new(klass, all_records, conditions, order_values)
     end

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -341,6 +341,22 @@ describe ActiveHash, "Base" do
     end
   end
 
+  describe ".invert_where" do
+    before do
+      Country.field :name
+      Country.field :language
+      Country.data = [
+        {:id => 1, :name => "US", :language => 'English'},
+        {:id => 2, :name => "Canada", :language => 'English'},
+        {:id => 3, :name => "Mexico", :language => 'Spanish'}
+      ]
+    end
+
+    it "inverts all conditions" do
+      expect(Country.where(id: 1).where.not(id: 3).invert_where.map(&:name)).to match_array(%w(Mexico))
+    end
+  end
+
   describe ".where.not" do
     before do
       Country.field :name

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -205,6 +205,29 @@ describe ActiveHash, "Base" do
     end
   end
 
+  describe ".reload" do
+    before do
+      Country.field :name
+      Country.field :language
+      Country.data = [
+        {:id => 1, :name => "US", :language => 'English'},
+        {:id => 2, :name => "Canada", :language => 'English'},
+        {:id => 3, :name => "Mexico", :language => 'Spanish'}
+      ]
+    end
+
+    it "it reloads cached records" do
+      countries = Country.where(language: 'Spanish')
+      expect(countries.count).to eq(1)
+
+      Country.create(id: 4, name: 'Spain', language: 'Spanish')
+
+      expect(countries.count).to eq(1)
+      countries.reload
+      expect(countries.count).to eq(2)
+    end
+  end
+
   describe ".where" do
     before do
       Country.field :name
@@ -221,7 +244,7 @@ describe ActiveHash, "Base" do
     end
 
     it "returns WhereChain class if no conditions are provided" do
-      expect(Country.where.class).to eq(ActiveHash::Base::WhereChain)
+      expect(Country.where.class).to eq(ActiveHash::Relation::WhereChain)
     end
 
     it "returns all records when passed nil" do
@@ -988,9 +1011,42 @@ describe ActiveHash, "Base" do
 
     it "populates the data correctly in the order provided" do
       countries = Country.where(language: 'English').order(id: :desc)
+
       expect(countries.count).to eq 2
       expect(countries.first).to eq Country.find_by(name: "Canada")
       expect(countries.second).to eq Country.find_by(name: "US")
+    end
+
+    it "can be chained" do
+      countries = Country.order(language: :asc)
+      expect(countries.first).to eq Country.find_by(name: "US")
+
+      countries = countries.order(name: :asc)
+      expect(countries.first).to eq Country.find_by(name: "Canada")
+    end
+
+    it "doesn't change the order of original records" do
+      countries = Country.order(id: :desc)
+
+      expect(countries.first).to eq Country.find_by(name: "Mexico")
+      expect(countries.second).to eq Country.find_by(name: "Canada")
+      expect(countries.third).to eq Country.find_by(name: "US")
+
+      expect(countries.find(1)).to eq Country.find_by(name: "US")
+
+      expect(Country.all.first).to eq Country.find_by(name: "US")
+      expect(Country.all.second).to eq Country.find_by(name: "Canada")
+      expect(Country.all.third).to eq Country.find_by(name: "Mexico")
+    end
+  end
+
+  describe ".reorder" do
+    it "re-orders records" do
+      countries = Country.order(language: :asc)
+      expect(countries.first).to eq Country.find_by(name: "US")
+
+      countries = countries.reorder(id: :desc)
+      expect(countries.first).to eq Country.find_by(name: "Mexico")
     end
   end
 


### PR DESCRIPTION
This PR adresses the same issues as #266, #265, #257, #193 and #261 at once, by adressing the 'root' of the issue - namely the mutating methods on `Relation`.

While #266 and #265 also adresses this in isolation, this PR is an alternative addressing the kinda messy structure of `Relation` and `WhereChain`, by extracting the condition predicate matching to their own `Condition` class. The conditions are evaluated lazily when filtering on the records of a relation should happen.

By doing it like this, it can open up for supporting more of the Rails scoping API such as `#reorder` and eg. `#invert_where`. Both are included here in the PR.