### PR TITLE
Fix #pluck method behavior when 3+ attributes specified

### DIFF
--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -73,7 +73,16 @@ module ActiveHash
     end
 
     def pluck(*column_names)
-      column_names.map { |column_name| all.map(&column_name.to_sym) }.inject(&:zip)
+      symbolized_column_names = column_names.map(&:to_sym)
+
+      if symbolized_column_names.length == 1
+        column_name = symbolized_column_names.first
+        all.map { |record| record[column_name] }
+      else
+        all.map do |record|
+          symbolized_column_names.map { |column_name| record[column_name] }
+        end
+      end
     end
 
     def ids

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -527,17 +527,22 @@ describe ActiveHash, "Base" do
   describe ".pluck" do
     before do
       Country.data = [
-        {:id => 1, :name => "US"},
-        {:id => 2, :name => "Canada"}
+        {:id => 1, :name => "US", :language => "English"},
+        {:id => 2, :name => "Canada", :language => "English"},
+        {:id => 3, :name => "Mexico", :language => "Spanish"}
       ]
     end
 
-    it "returns an two dimensional Array of attributes values" do
-      expect(Country.pluck(:id, :name)).to match_array([[1,"US"], [2, "Canada"]])
+    it "returns an two dimensional Array of 3 attributes values" do
+      expect(Country.pluck(:id, :name, :language)).to match_array([[1, "US", "English"], [2, "Canada", "English"], [3, "Mexico", "Spanish"]])
+    end
+
+    it "returns an two dimensional Array of 2 attributes values" do
+      expect(Country.pluck(:id, :name)).to match_array([[1, "US"], [2, "Canada"], [3, "Mexico"]])
     end
 
     it "returns an Array of attribute values" do
-      expect(Country.pluck(:id)).to match_array([1,2])
+      expect(Country.pluck(:id)).to match_array([1, 2, 3])
     end
   end
 


### PR DESCRIPTION
Hi. I noticed that ActiveHash's `#pluck` method behaves differently from ActiveRecord one. This pull request fixes the issue.

### Current behavior (ActiveHash v3.1.1)

```ruby
Category.pluck(:id, :name, :language)
=> [
  [[1, "US"], "English"],
  [[2, "Canada"], "English"],
  [[3, "Mexico"], "Spanish"]
]
```

### Expected behavior (same as ActiveRecord)

```ruby
Category.pluck(:id, :name, :language)
=> [
  [1, "US", "English"],
  [2, "Canada", "English"],
  [3, "Mexico", "Spanish"]
]
```
