### PR TITLE
Avoid interfering with AR's belongs_to arguments.

### DIFF
--- a/lib/associations/associations.rb
+++ b/lib/associations/associations.rb
@@ -4,16 +4,16 @@ module ActiveHash
     module ActiveRecordExtensions
 
       def belongs_to(name, scope = nil, **options)
-        options = {:class_name => name.to_s.camelize }.merge(options)
+        klass_name = options.key?(:class_name) ? options[:class_name] : name.to_s.camelize
         klass =
           begin
-            options[:class_name].constantize
-          rescue
-            nil
-          rescue LoadError
+            klass_name.constantize
+          rescue StandardError, LoadError
             nil
           end
+
         if klass && klass < ActiveHash::Base
+          options = { class_name: klass_name }.merge(options)
           belongs_to_active_hash(name, options)
         else
           super

--- a/spec/associations/active_record_extensions_spec.rb
+++ b/spec/associations/active_record_extensions_spec.rb
@@ -166,6 +166,13 @@ unless SKIP_ACTIVE_RECORD
           expect(school.country).to eq(nil)
         end
 
+        it "doesn't interfere with AR's belongs_to arguments" do
+          allow(ActiveRecord::Base).to receive(:belongs_to).with(:country, nil)
+          allow(ActiveRecord::Base).to receive(:belongs_to).with(:country, nil, {})
+
+          School.belongs_to :country
+        end
+
         it "doesn't interfere w/ ActiveRecord's polymorphism" do
           School.belongs_to :locateable, :polymorphic => true
           school = School.new


### PR DESCRIPTION
# Background
In active_hash v3.1.0, `ActiveHash::Associations::ActiveRecordExtensions#belongs_to` copies arguments and calls `super` with no arguments.
It doesn't interfere with AR's `belongs_to` arguments.

https://github.com/active-hash/active_hash/blob/d952d67a0a52ee78f899366925757a79e4de6c37/lib/associations/associations.rb#L6-L24

However, after active_hash v3.1.1, it doesn't copy arguments and updates `options` from arguments and calls `super` with no arguments.
It interferes with AR's `belongs_to` arguments (please reference rspec in this PR).

# Changes
In this PR, avoid `ActiveHash::Associations::ActiveRecordExtensions#belongs_to` interfering with AR's `belongs_to` arguments.
(In addition, refactored the error handling as minor fix.)