### PR TITLE
Bugfix: Allow chaining with same attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,11 +211,11 @@ Country#name=       # => sets the name
 The ActiveHash::Base.all method functions like an in-memory data store. You can save your records as ActiveHash::Relation object by using standard ActiveRecord create and save methods:
 ```ruby
 Country.all
-=> #<ActiveHash::Relation:0x00007f861e043bb0 @klass=Country, @all_records=[], @query_hash={}, @records_dirty=false>
+=> #<ActiveHash::Relation:0x00007f861e043bb0 @klass=Country, @all_records=[], @query_list=[], @records_dirty=false>
 Country.create
 => #<Country:0x00007f861b7abce8 @attributes={:id=>1}>
 Country.all
-=> #<ActiveHash::Relation:0x00007f861b7b3628 @klass=Country, @all_records=[#<Country:0x00007f861b7abce8 @attributes={:id=>1}>], @query_hash={}, @records_dirty=false>
+=> #<ActiveHash::Relation:0x00007f861b7b3628 @klass=Country, @all_records=[#<Country:0x00007f861b7abce8 @attributes={:id=>1}>], @query_list=[], @records_dirty=false>
 country = Country.new
 => #<Country:0x00007f861e059938 @attributes={}>
 country.new_record?
@@ -225,7 +225,7 @@ country.save
 country.new_record?
 # => false
 Country.all
-=> #<ActiveHash::Relation:0x00007f861e0ca610 @klass=Country, @all_records=[#<Country:0x00007f861b7abce8 @attributes={:id=>1}>, #<Country:0x00007f861e059938 @attributes={:id=>2}>], @query_hash={}, @records_dirty=false>
+=> #<ActiveHash::Relation:0x00007f861e0ca610 @klass=Country, @all_records=[#<Country:0x00007f861b7abce8 @attributes={:id=>1}>, #<Country:0x00007f861e059938 @attributes={:id=>2}>], @query_list=[], @records_dirty=false>
 ```
 Notice that when adding records to the collection, it will auto-increment the id for you by default.  If you use string ids, it will not auto-increment the id.  Available methods are:
 ```

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -43,7 +43,7 @@ module ActiveHash
           options.present? && match_options?(record, options)
         end
 
-        ActiveHash::Relation.new(@scope.klass, filtered_records, {})
+        ActiveHash::Relation.new(@scope.klass, filtered_records, [])
       end
 
       def match_options?(record, options)
@@ -205,7 +205,7 @@ module ActiveHash
       end
 
       def all(options = {})
-        ActiveHash::Relation.new(self, @records || [], options[:conditions] || {})
+        ActiveHash::Relation.new(self, @records || [], options[:conditions].to_a)
       end
 
       delegate :where, :find, :find_by, :find_by!, :find_by_id, :count, :pluck, :ids, :pick, :first, :last, :order, to: :all

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -307,14 +307,19 @@ describe ActiveHash, "Base" do
       expect(Country.where(:name => [:US, :Canada]).map(&:name)).to match_array(%w(US Canada))
     end
 
-    it 'is chainable' do
-      where_relation = Country.where(language: 'English')
+    it "is chainable" do
+      where_relation = Country.where(language: "English")
 
       expect(where_relation.length).to eq 2
       expect(where_relation.map(&:id)).to eq([1, 2])
-      chained_where_relation = where_relation.where(name: 'US')
+      chained_where_relation = where_relation.where(name: "US")
       expect(chained_where_relation.length).to eq 1
       expect(chained_where_relation.map(&:id)).to eq([1])
+    end
+
+    it "is chainable with same attribute" do
+      expect(Country.where(id: 1..2).where(id: 2..3).pluck(:id)).to match_array([2])
+      expect(Country.where(language: "English").where(language: "Spanish").length).to eq 0
     end
   end
 
@@ -409,6 +414,14 @@ describe ActiveHash, "Base" do
 
     it "filters records for multiple conditions" do
       expect(Country.where.not(:id => 1, :name => 'Mexico')).to match_array([Country.find(2)])
+    end
+
+    it "is chainable with where" do
+      expect(Country.where.not(name: "US").where(language: "English").pluck(:name)).to match_array(["Canada"])
+    end
+
+    it "is chainable with where for same attribute" do
+      expect(Country.where(id: 2..3).where(id: 1..3).where.not(id: 1..2).where.not(id: 1).pluck(:id)).to match_array([3])
     end
   end
 


### PR DESCRIPTION
Expected behavior:
```ruby
Country.where(id: 1).where(id: 2) # []
```
Current behavior:
```ruby
Country.where(id: 1).where(id: 2) # [#< Country id=2>]