### PR TITLE
Rails 7 support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,8 +16,7 @@ jobs:
         # | 6.1   |           |          |   2.5   |     |
         # | 7.0   |           |          |   2.7   |     |
         ruby: ['3.0', '3.1']
-        gemfile: ['gemfiles/rails_6.1.gemfile']
-          #   gemfile: 'gemfiles/rails_7.0.gemfile'
+        gemfile: ['gemfiles/rails_6.1.gemfile', 'gemfiles/rails_7.0.gemfile']
         include:
         - ruby: '2.4'
           gemfile: 'gemfiles/rails_5.0.gemfile'

--- a/lib/associations/associations.rb
+++ b/lib/associations/associations.rb
@@ -49,13 +49,20 @@ module ActiveHash
         end
 
         if ActiveRecord::Reflection.respond_to?(:create)
-          reflection = ActiveRecord::Reflection.create(
-            :belongs_to,
-            association_id.to_sym,
-            nil,
-            options,
-            self
-          )
+          if defined?(ActiveHash::Reflection::BelongsToReflection)
+            reflection = ActiveHash::Reflection::BelongsToReflection.new(association_id.to_sym, nil, options, self)
+            if options[:through]
+              reflection = ActiveRecord::ThroughReflection.new(reflection)
+            end
+          else
+            reflection = ActiveRecord::Reflection.create(
+              :belongs_to,
+              association_id.to_sym,
+              nil,
+              options,
+              self
+            )
+          end
 
           ActiveRecord::Reflection.add_reflection(
             self,
@@ -85,6 +92,7 @@ module ActiveHash
     end
 
     def self.included(base)
+      require_relative "reflection_extensions"
       base.extend Methods
     end
 

--- a/lib/associations/reflection_extensions.rb
+++ b/lib/associations/reflection_extensions.rb
@@ -1,0 +1,25 @@
+module ActiveHash
+  module Reflection
+    class BelongsToReflection < ActiveRecord::Reflection::BelongsToReflection
+      def compute_class(name)
+        if polymorphic?
+          raise ArgumentError, "Polymorphic associations do not support computing the class."
+        end
+        
+        begin
+          klass = active_record.send(:compute_type, name)
+        rescue NameError => error
+          if error.name.match?(/(?:\A|::)#{name}\z/)
+            message = "Missing model class #{name} for the #{active_record}##{self.name} association."
+            message += " You can specify a different model class with the :class_name option." unless options[:class_name]
+            raise NameError.new(message, name)
+          else
+            raise
+          end
+        end
+
+        klass
+      end
+    end
+  end
+end

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -1370,6 +1370,9 @@ describe ActiveHash, "Base" do
           t.integer :subject_id
           t.integer :country_id
         end
+
+        extend ActiveHash::Associations::ActiveRecordExtensions
+
         belongs_to :subject, :polymorphic => true
         belongs_to :country
       end

--- a/spec/associations/active_record_extensions_spec.rb
+++ b/spec/associations/active_record_extensions_spec.rb
@@ -138,7 +138,7 @@ unless SKIP_ACTIVE_RECORD
         it "only uses 1 query" do
           Author.has_many :books
           author = Author.create :id => 1
-          expect(Book).to receive(:find_by_sql)
+          expect(Book).to receive(:where).with(author_id: 1).once.and_call_original
           author.books.to_a
         end
       end


### PR DESCRIPTION
Alternative implementation to #267 that doesn't monkeypatch ActiveRecord.

This implementation subclasses `ActiveRecord::Reflection::BelongsToReflection` and overrides the `compute_class` method to allow ActiveHash associations.

I've also cherry-picked some relevant commits from #267.
