### PR TITLE
ci: avoid running multiple times on the same commit

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,6 +1,17 @@
 name: Ruby
-
-on: [push, pull_request]
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*.*.*
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - '*'
 
 jobs:
   build:


### PR DESCRIPTION
CI runs the same jobs under both "push" and "pull_request", which looks like this:

![image](https://user-images.githubusercontent.com/8207/212760305-a660fc6a-078c-42da-a413-aea66f01ef58.png)


This config avoids running multiple times on the same PR, resulting in the deduped checks you can see below.