### PR TITLE
Bugfix: Use correct value for field attributes when default field value is `false`

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -237,7 +237,7 @@ module ActiveHash
         validate_field(field_name)
         field_names << field_name
 
-        add_default_value(field_name, options[:default]) if options[:default]
+        add_default_value(field_name, options[:default]) if options.key?(:default)
         define_getter_method(field_name, options[:default])
         define_setter_method(field_name)
         define_interrogator_method(field_name)

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -1173,6 +1173,17 @@ describe ActiveHash, "Base" do
           country = Country.new
           expect(country.attributes[:name]).to eq("foobar")
         end
+
+        context "when the default value is false" do
+          before do
+            Country.field :active, :default => false
+          end
+    
+          it "returns the default value when not present" do
+            country = Country.new
+            expect(country.attributes[:active]).to eq(false)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Given a class with a default value of `false` for a field:

```rb
class Country < ActiveHash::Base
  field :active, default: false

  self.data = [
    {:id => 1, :name => "US", :active => true},
    {:id => 2, :name => "Canada"}
  ]
end
```

I'd expect that accessing the field would return `false` when accessed via the attributes hash or via the method for the field:

```rb
Country.find(2)[:active]            # false
Country.find(2).attributes[:active] # false
Country.find(2).active              # false
```

But the attributes hash returns `nil` (tho the method for the field works as expected and returns `false`):

```rb
Country.find(2)[:active]            # nil
Country.find(2).attributes[:active] # nil
Country.find(2).active              # false
```

This PR fixes this behavior by ensuring the default value is correctly set as long as there's a key of `default` passed to the `field` method.

I added a spec for this bug, saw it fail, made the change, and confirmed all specs pass.