### PR TITLE
fix: provide a cleaner method missing error

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -21,7 +21,7 @@ module ActiveHash
   end
 
   class Base
-    class_attribute :_data, :dirty, :default_attributes, :scopes
+    class_attribute :_data, :dirty, :default_attributes
 
     if Object.const_defined?(:ActiveModel)
       extend ActiveModel::Naming
@@ -33,6 +33,9 @@ module ActiveHash
     end
 
     class << self
+      def scopes
+        @scopes ||= {}
+      end
 
       def cache_key
         if Object.const_defined?(:ActiveModel)
@@ -372,7 +375,6 @@ module ActiveHash
       def scope(name, body)
         raise ArgumentError, 'body needs to be callable' unless body.respond_to?(:call)
 
-        self.scopes ||= {}
         self.scopes[name] = body
 
         the_meta_class.instance_eval do


### PR DESCRIPTION
I hit a weird error that ultimately was my fault, but it exposed a use-before-initialize bug in `ActiveHash::Relation#method_missing` on the `.scopes` class_attribute. I changed the class_attribute to a class method with a memoized class variable that is lazily initialized on reference.

This is a low-impact addition.