### PR TITLE
Fix nil scopes in method_missing and respond_to_missing?

### DIFF
--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -164,13 +164,13 @@ module ActiveHash
     end
 
     def method_missing(method_name, *args)
-      return super unless klass.scopes.key?(method_name)
+      return super unless klass.scopes&.key?(method_name)
 
       instance_exec(*args, &klass.scopes[method_name])
     end
 
     def respond_to_missing?(method_name, include_private = false)
-      klass.scopes.key?(method_name) || super
+      klass.scopes&.key?(method_name) || super
     end
 
     private


### PR DESCRIPTION
I ran into this error after I upgraded an app to Rails 7, which seems to have changed [how association reflections are handled](https://github.com/active-hash/active_hash/pull/272) ?

Anyway, `method_missing` and `respond_to_missing?` were failing because of `scopes` being nil, which is always the case unless you specify at least one `scope`:

https://github.com/active-hash/active_hash/blob/7a07bcc07abca9aca48b47186c23f85cf6ec7ced/lib/active_hash/base.rb#L375-L376

I've fixed this using safe navigation. An alternative would be to declare a default for the `class_attribute` here:
https://github.com/active-hash/active_hash/blob/7a07bcc07abca9aca48b47186c23f85cf6ec7ced/lib/active_hash/base.rb#L24-L25

Let me know what you prefer!