### PR TITLE
Condition explicitly uses attribute values and not public_send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # active_hash Changelog
 
+## next - unreleased
+
+- Fix relation matching when attribute name collides with a method. [#281](https://github.com/active-hash/active_hash/pull/281) @flavorjones
+
+
 ## Version [3.2.0] - <sub><sup>2022-07-14</sup></sub>
 
 - Add Ruby 3.2 to the CI matrix [#275](https://github.com/active-hash/active_hash/pull/275) @petergoldstein

--- a/lib/active_hash/condition.rb
+++ b/lib/active_hash/condition.rb
@@ -19,7 +19,7 @@ class ActiveHash::Relation::Condition
       expectation_method = inverted ? :any? : :all?
 
       constraints.send(expectation_method) do |attribute, expected|
-        value = record.public_send(attribute)
+        value = record.read_attribute(attribute)
 
         matches_value?(value, expected)
       end

--- a/spec/active_hash/relation_spec.rb
+++ b/spec/active_hash/relation_spec.rb
@@ -50,4 +50,25 @@ RSpec.describe ActiveHash::Relation do
       expect(array.size).to eq(2)
     end
   end
+
+  describe "colliding methods https://github.com/active-hash/active_hash/issues/280" do
+    it "should handle attributes named after existing methods" do
+      klass = Class.new(ActiveHash::Base) do
+        self.data = [
+          {
+            id: 1,
+            name: "Aaa",
+            display: true,
+          },
+          {
+            id: 2,
+            name: "Bbb",
+            display: false,
+          },
+        ]
+      end
+
+      expect(klass.where(display: true).length).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
fix: Condition explicitly uses attribute values and not public_send

Using public_send caused an issue when attribute names shadowed method names.

Closes #280