### PR TITLE
Fix nil error

### DIFF
--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -170,7 +170,7 @@ module ActiveHash
     end
 
     def respond_to_missing?(method_name, include_private = false)
-      klass.scopes.key?(method_name) || super
+      klass.scopes&.key?(method_name) || super
     end
 
     private


### PR DESCRIPTION
I was getting a backtrace like [this](https://gist.github.com/vinnydiehl/19f83a65bac2f77c7807dce090271b7a) somewhat arbitrarily throughout my application when running on RSpec/Capybara.