### PR TITLE
require reflection_extensions when ActiveRecordExtensions is extended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## next - unreleased
 
 - Fix relation matching when attribute name collides with a method. [#281](https://github.com/active-hash/active_hash/pull/281) @flavorjones
+- Fix association reflection in applications that don't use ActiveHash::Associations. [#286](https://github.com/active-hash/active_hash/pull/286) @iberianpig
 
 
 ## Version [3.2.0] - <sub><sup>2023-05-06</sup></sub>

--- a/lib/associations/associations.rb
+++ b/lib/associations/associations.rb
@@ -3,6 +3,10 @@ module ActiveHash
 
     module ActiveRecordExtensions
 
+      def self.extended(base)
+        require_relative 'reflection_extensions'
+      end
+
       def belongs_to(name, scope = nil, **options)
         klass_name = options.key?(:class_name) ? options[:class_name] : name.to_s.camelize
         klass =
@@ -92,7 +96,6 @@ module ActiveHash
     end
 
     def self.included(base)
-      require_relative "reflection_extensions"
       base.extend Methods
     end
 


### PR DESCRIPTION
**Problem**

Previously, unless `include ActiveHash::Associations` was executed, the override to `compute_class` when setting `belongs_to_active_hash` would not be performed. This is an unintended behavior.

When `compute_class` is called in Rails 7, the following error occurs:

```
ArgumentError: Rails couldn't find a valid model for Rank association.
Please provide the :class_name option on the association declaration.
If :class_name is already provided, make sure it's an ActiveRecord::Base subclass.
```

**Solution**

This pull request proposes a change to `require "reflection_extensions"` when `extend ActiveHash::Associations::ActiveRecordExtensions` is called instead of `include ActiveHash::Associations`

The reflection is defined only when `extend ActiveHash::Associations::ActiveRecordExtensions`.
As a result, the `compute_class` is properly overridden.