### PR TITLE
Fix (Relation): add safe navigator operator after scopes for respond_to_missing? and method_missing methods

### DIFF
--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -164,13 +164,13 @@ module ActiveHash
     end
 
     def method_missing(method_name, *args)
-      return super unless klass.scopes.key?(method_name)
+      return super unless klass.scopes&.key?(method_name)
 
       instance_exec(*args, &klass.scopes[method_name])
     end
 
     def respond_to_missing?(method_name, include_private = false)
-      klass.scopes.key?(method_name) || super
+      klass.scopes&.key?(method_name) || super
     end
 
     private


### PR DESCRIPTION
Hello ! 

In our attempt to move our project to Ruby 3.2.2 we encountered an error : `MethodError: undefined method 'key?' for nil:NilClass`, the origin of the error was from `relation.rb:173`, our class did not had any scopes and so it was sending this error. We had multiples ideas to fix the issue but the simplest one was to just add a safe navigator operator. What do you think about that ? I'm available if you need me to do any other modifications.

Thank you !