### PR TITLE
feat: improve pp output for ActiveHash::Relation

### DIFF
--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -22,6 +22,10 @@ module ActiveHash
       spawn.where!(conditions_hash)
     end
 
+    def pretty_print(pp)
+      pp.pp(entries.to_ary)
+    end
+
     class WhereChain
       attr_reader :relation
 

--- a/spec/active_hash/relation_spec.rb
+++ b/spec/active_hash/relation_spec.rb
@@ -71,4 +71,16 @@ RSpec.describe ActiveHash::Relation do
       expect(klass.where(display: true).length).to eq(1)
     end
   end
+
+  describe "#pretty_print" do
+    it "prints the records" do
+      out = StringIO.new
+      PP.pp(subject, out)
+
+      expect(out.string.scan(/\bid\b/).length).to eq(2)
+      expect(out.string).to match(/\bCanada\b/)
+      expect(out.string).to match(/\bUS\b/)
+      expect(out.string).to_not match(/ActiveHash::Relation/)
+    end
+  end
 end


### PR DESCRIPTION
Previously the output might look like:

    #<ActiveHash::Relation:0x00007f4c2dc3ca28
     @all_records=
      [#<Layout:0x00007f4c2df4f198 @attributes={:id=>1, :name=>"1"}>,
       #<Layout:0x00007f4c2df4cfd8 @attributes={:id=>2, :name=>"2"}>,
       #<Layout:0x00007f4c2df4b9a8 @attributes={:id=>3, :name=>"3"}>,
       #<Layout:0x00007f4c2df7d9f8 @attributes={:id=>4, :name=>"4"}>],
     @conditions=#<ActiveHash::Relation::Conditions:0x00007f4c2dc3bd58 @conditions=[]>,
     @klass=Layout,
     @order_values=[]>

After this change the output looks like:

    [#<Layout:0x00007f2755785d60 @attributes={:id=>1, :name=>"1"}>,
     #<Layout:0x00007f2755784668 @attributes={:id=>2, :name=>"2"}>,
     #<Layout:0x00007f2755783a38 @attributes={:id=>3, :name=>"3"}>,
     #<Layout:0x00007f2755782db8 @attributes={:id=>4, :name=>"4"}>]

Closes #285