### PR TITLE
release v3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ## next - unreleased
 
+### Added
+
+- Improve `pp` output for `ActiveHash::Relation`. [#288](https://github.com/active-hash/active_hash/pull/288) @flavorjones
+
+### Fixed
+
 - Fix relation matching when attribute name collides with a method. [#281](https://github.com/active-hash/active_hash/pull/281) @flavorjones
 - Fix association reflection in applications that don't use ActiveHash::Associations. [#286](https://github.com/active-hash/active_hash/pull/286) @iberianpig
+- Fix `ActiveHash::Relation#method_missing` and `#respond_to_missing?` without scopes. [#278](https://github.com/active-hash/active_hash/pull/278) @julianrubisch
 
 
 ## Version [3.2.0] - <sub><sup>2023-05-06</sup></sub>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # active_hash Changelog
 
-## next - unreleased
+## Version [3.2.1] - <sub><sup>2023-08-31</sup></sub>
 
 ### Added
 

--- a/lib/active_hash/version.rb
+++ b/lib/active_hash/version.rb
@@ -1,5 +1,5 @@
 module ActiveHash
   module Gem
-    VERSION = "3.2.0"
+    VERSION = "3.2.1"
   end
 end


### PR DESCRIPTION
changelog:

## Version [3.2.1] - <sub><sup>2023-08-31</sup></sub>

### Added

- Improve `pp` output for `ActiveHash::Relation`. [#288](https://github.com/active-hash/active_hash/pull/288) @flavorjones

### Fixed

- Fix relation matching when attribute name collides with a method. [#281](https://github.com/active-hash/active_hash/pull/281) @flavorjones
- Fix association reflection in applications that don't use ActiveHash::Associations. [#286](https://github.com/active-hash/active_hash/pull/286) @iberianpig
- Fix `ActiveHash::Relation#method_missing` and `#respond_to_missing?` without scopes. [#278](https://github.com/active-hash/active_hash/pull/278) @julianrubisch


