### PR TITLE
Support Rails 7.1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,8 +26,9 @@ jobs:
         # | 6.0   |  6/2023?  |   3/3023?|   2.5   | 2.7 |
         # | 6.1   |           |          |   2.5   |     |
         # | 7.0   |           |          |   2.7   |     |
+        # | 7.1   |           |          |   2.7   |     |
         ruby: ['3.0', '3.1', '3.2']
-        gemfile: ['gemfiles/rails_6.1.gemfile', 'gemfiles/rails_7.0.gemfile']
+        gemfile: ['gemfiles/rails_6.1.gemfile', 'gemfiles/rails_7.0.gemfile', 'gemfiles/rails_7.1.gemfile']
         include:
         - ruby: '2.4'
           gemfile: 'gemfiles/rails_5.0.gemfile'

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -1,0 +1,17 @@
+source 'http://rubygems.org/'
+
+gem 'activerecord', '~> 7.1.0'
+gem 'rspec', '~> 3.9'
+gem 'rake', '~> 13.0'
+gem 'json'
+gem 'test-unit'
+
+platform :jruby do
+  gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.6'
+end
+
+platform :ruby do
+  gem 'sqlite3'
+end
+
+gemspec :path => '../'

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -349,6 +349,11 @@ module ActiveHash
         base_class.name
       end
 
+      # Needed for ActiveRecord since rails/rails#47664
+      def composite_primary_key?
+        false
+      end
+
       def reload
         reset_record_index
         self.data = _data


### PR DESCRIPTION
This PR adds Rails 7.1 to the test matrix.

And, implementing `composte_primary_key?` method because Active Record uses this method since https://github.com/rails/rails/pull/47664
 in some places.

Without this method, a spec fails with the following error.

```
 NoMethodError:
   undefined method `composite_primary_key?' for Country:Class
 # ./lib/active_hash/base.rb:227:in `method_missing'
 # lib/ruby/gems/3.2.0/gems/activerecord-7.1.1/lib/active_record/reflection.rb:863:in `association_primary_key'
 # lib/ruby/gems/3.2.0/gems/activerecord-7.1.1/lib/active_record/associations/belongs_to_association.rb:138:in `primary_key'
 # lib/ruby/gems/3.2.0/gems/activerecord-7.1.1/lib/active_record/associations/belongs_to_association.rb:127:in `replace_keys'
 # lib/ruby/gems/3.2.0/gems/activerecord-7.1.1/lib/active_record/associations/belongs_to_polymorphic_association.rb:26:in `replace_keys'
 # lib/ruby/gems/3.2.0/gems/activerecord-7.1.1/lib/active_record/associations/belongs_to_association.rb:98:in `replace'
 # lib/ruby/gems/3.2.0/gems/activerecord-7.1.1/lib/active_record/associations/singular_association.rb:19:in `writer'
 # lib/ruby/gems/3.2.0/gems/activerecord-7.1.1/lib/active_record/associations/builder/association.rb:112:in `subject='
 # ./spec/active_hash/base_spec.rb:1476:in `block (3 levels) in <top (required)>'
```

Ref: https://github.com/y-yagi/active_hash/actions/runs/6544200231/job/17770198096#step:4:15