### PR TITLE
Fix #where for hashes with string keys

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -411,7 +411,7 @@ module ActiveHash
     end
 
     def _read_attribute(key)
-      attributes[key]
+      attributes[key.to_sym]
     end
     alias_method :read_attribute, :_read_attribute
 

--- a/lib/active_hash/condition.rb
+++ b/lib/active_hash/condition.rb
@@ -19,7 +19,7 @@ class ActiveHash::Relation::Condition
       expectation_method = inverted ? :any? : :all?
 
       constraints.send(expectation_method) do |attribute, expected|
-        value = record.read_attribute(attribute.to_sym)
+        value = record.read_attribute(attribute)
 
         matches_value?(value, expected)
       end

--- a/lib/active_hash/condition.rb
+++ b/lib/active_hash/condition.rb
@@ -19,7 +19,7 @@ class ActiveHash::Relation::Condition
       expectation_method = inverted ? :any? : :all?
 
       constraints.send(expectation_method) do |attribute, expected|
-        value = record.read_attribute(attribute)
+        value = record.read_attribute(attribute.to_sym)
 
         matches_value?(value, expected)
       end

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -1201,10 +1201,22 @@ describe ActiveHash, "Base" do
       expect(country._read_attribute(:foo)).to eq(:bar)
     end
 
+    it "works when string key passed to _read_attribute" do
+      Country.field :foo
+      country = Country.new(:foo => :bar)
+      expect(country._read_attribute('foo')).to eq(:bar)
+    end
+
     it "works with read_attribute" do
       Country.field :foo
       country = Country.new(:foo => :bar)
       expect(country.read_attribute(:foo)).to eq(:bar)
+    end
+
+    it "works when string key passed to read_attribute" do
+      Country.field :foo
+      country = Country.new(:foo => :bar)
+      expect(country.read_attribute('foo')).to eq(:bar)
     end
 
     it "works with #[]=" do

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -284,6 +284,13 @@ describe ActiveHash, "Base" do
       expect(record.first.name).to eq('US')
     end
 
+    it "filters records when passed a hash with string keys" do
+      record = Country.where('name' => 'US')
+      expect(record.count).to eq(1)
+      expect(record.first.id).to eq(1)
+      expect(record.first.name).to eq('US')
+    end
+
     it "raises an error if ids aren't unique" do
       expect do
         Country.data = [


### PR DESCRIPTION
✌️  Hey `active_hash` maintainers ✌️ Thank you for such great gem that makes development with ruby even more productive 🙇 

I noticed that the latest version (`v3.2.1`) has undocumented side-effect which affect the behaviour of one of the core features - search. To be specific the `#where` for hash with string keys stopped working (example: `ActiveHashModel.where("id" => 1)`).
It seems that transition from `Object#public_send ` to `ActiveHash::Base#read_attribute` (in #281) isn't backward-compatible as those methods have a bit different expectation towards arguments. [Object#public_send](https://apidock.com/ruby/Object/public_send#:~:text=When%20the%20method%20is%20identified%20by%20a%20string%2C%20the%20string%20is%20converted%20to%20a%20symbol) - converts arguments to symbols, `read_attribute` - not (while `attributes` internally are stored with symbolized keys).

<details>
  <summary>Small demo</summary>

```ruby
(rdbg) pp record
#<Category:0x000000012a0d7db8 @attributes={:id=>1, :name=>"qwerty"}>
(rdbg) pp record.read_attribute("id")
nil
(rdbg) pp record.public_send(:id)
1
(rdbg) pp record.attributes["id"]
nil
(rdbg) pp record.attributes[:id]
1
(rdbg) pp record.id
1
```  
  
</details>