### PR TITLE
Treat nil and blank values as different

### DIFF
--- a/lib/active_hash/condition.rb
+++ b/lib/active_hash/condition.rb
@@ -39,6 +39,6 @@ class ActiveHash::Relation::Condition
   end
 
   def normalize(value)
-    value.respond_to?(:to_s) ? value.to_s : value
+    value.respond_to?(:to_s) ? value&.to_s : value
   end
 end

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -465,7 +465,8 @@ describe ActiveHash, "Base" do
       Country.data = [
         {:id => 1, :name => "US", :language => 'English'},
         {:id => 2, :name => "Canada", :language => 'English'},
-        {:id => 3, :name => "Mexico", :language => 'Spanish'}
+        {:id => 3, :name => "Mexico", :language => 'Spanish'},
+        {:id => 5, :name => "Any", :language => nil}
       ]
     end
 
@@ -523,6 +524,14 @@ describe ActiveHash, "Base" do
 
     it "returns nil when passed a wrong id" do
       expect(Country.find_by(:id => 4)).to be_nil
+    end
+
+    it "finds record by nil value" do
+      expect(Country.find_by(:language => nil).id).to eq(5)
+    end
+
+    it "doesn't finds nil records when searching for ''" do
+      expect(Country.find_by(:language => '')).to be_nil
     end
   end
 


### PR DESCRIPTION
Before:
When searching for "", it found records with a nil value.

After:
It will find nil values when searching for nil
It will not find nil values when searching for ''

fixes #293