### PR TITLE
support `has_many :through` associations

### DIFF
--- a/lib/associations/associations.rb
+++ b/lib/associations/associations.rb
@@ -55,9 +55,6 @@ module ActiveHash
         if ActiveRecord::Reflection.respond_to?(:create)
           if defined?(ActiveHash::Reflection::BelongsToReflection)
             reflection = ActiveHash::Reflection::BelongsToReflection.new(association_id.to_sym, nil, options, self)
-            if options[:through]
-              reflection = ActiveRecord::ThroughReflection.new(reflection)
-            end
           else
             reflection = ActiveRecord::Reflection.create(
               :belongs_to,

--- a/lib/associations/associations.rb
+++ b/lib/associations/associations.rb
@@ -2,9 +2,33 @@ module ActiveHash
   module Associations
 
     module ActiveRecordExtensions
-
       def self.extended(base)
         require_relative 'reflection_extensions'
+      end
+
+      def has_many(association_id, **options)
+        if options[:through]
+          klass_name = association_id.to_s.classify
+          klass =
+            begin
+              klass_name.constantize
+            rescue StandardError, LoadError
+              nil
+            end
+
+          if klass && klass < ActiveHash::Base
+            define_method(association_id) do
+              join_models = send(options[:through])
+              join_models.flat_map do |join_model|
+                join_model.send(association_id.to_s.singularize)
+              end.uniq
+            end
+
+            return
+          end
+        end
+
+        super
       end
 
       def belongs_to(name, scope = nil, **options)
@@ -117,6 +141,7 @@ module ActiveHash
             klass.where(foreign_key => primary_key_value)
           end
         end
+
         define_method("#{association_id.to_s.underscore.singularize}_ids") do
           public_send(association_id).map(&:id)
         end
@@ -140,7 +165,6 @@ module ActiveHash
       end
 
       def belongs_to(association_id, options = {})
-
         options = {
           :class_name => association_id.to_s.classify,
           :foreign_key => association_id.to_s.foreign_key,
@@ -156,7 +180,6 @@ module ActiveHash
         define_method("#{association_id}=") do |new_value|
           attributes[options[:foreign_key].to_sym] = new_value ? new_value.send(options[:primary_key]) : nil
         end
-
       end
     end
 


### PR DESCRIPTION
This PR closes #239.

The first commit removes unused (and broken?) code that I found while looking at the association code. It was part of e6a47bcc and should not have been present.

The second commit refactors the extensions spec a bit to minimize the test classes being created for each test; this makes the tests more explicit and speeds them up slightly.

The final commit introduces the test from #239 and overrides the `has_many` method in any class that includes `ActiveHash::Associations::ActiveRecordExtensions`. The new implementation will adopt new behavior if the `:through` option is present and it points at an `ActiveHash::Base` class:

- retrieving the join models (e.g., "Patient#appointments")
- calling the `:through` association name on each join model (e.g., "Appointment#physician")
- and returning the unique matching records

Otherwise `has_many` will just call `super`.