### PR TITLE
prefer Active Support's String#safe_constantize to #constantize

### DIFF
--- a/lib/associations/associations.rb
+++ b/lib/associations/associations.rb
@@ -11,7 +11,7 @@ module ActiveHash
           klass_name = association_id.to_s.classify
           klass =
             begin
-              klass_name.constantize
+              klass_name.safe_constantize
             rescue StandardError, LoadError
               nil
             end
@@ -35,7 +35,7 @@ module ActiveHash
         klass_name = options.key?(:class_name) ? options[:class_name] : name.to_s.camelize
         klass =
           begin
-            klass_name.constantize
+            klass_name.safe_constantize
           rescue StandardError, LoadError
             nil
           end
@@ -55,11 +55,11 @@ module ActiveHash
           :shortcuts => []
         }.merge(options)
         # Define default primary_key with provided class_name if any
-        options[:primary_key] ||= options[:class_name].constantize.primary_key
+        options[:primary_key] ||= options[:class_name].safe_constantize.primary_key
         options[:shortcuts] = [options[:shortcuts]] unless options[:shortcuts].kind_of?(Array)
 
         define_method(association_id) do
-          options[:class_name].constantize.send("find_by_#{options[:primary_key]}", send(options[:foreign_key]))
+          options[:class_name].safe_constantize.send("find_by_#{options[:primary_key]}", send(options[:foreign_key]))
         end
 
         define_method("#{association_id}=") do |new_value|
@@ -72,7 +72,7 @@ module ActiveHash
           end
 
           define_method("#{association_id}_#{shortcut}=") do |new_value|
-            send "#{association_id}=", new_value ? options[:class_name].constantize.send("find_by_#{shortcut}", new_value) : nil
+            send "#{association_id}=", new_value ? options[:class_name].safe_constantize.send("find_by_#{shortcut}", new_value) : nil
           end
         end
 
@@ -109,7 +109,7 @@ module ActiveHash
               :belongs_to,
               association_id.to_sym,
               options,
-              options[:class_name].constantize
+              options[:class_name].safe_constantize
             )
           end
         end
@@ -129,7 +129,7 @@ module ActiveHash
             :primary_key => self.class.primary_key
           }.merge(options)
 
-          klass = options[:class_name].constantize
+          klass = options[:class_name].safe_constantize
           primary_key_value = send(options[:primary_key])
           foreign_key = options[:foreign_key].to_sym
 
@@ -155,7 +155,7 @@ module ActiveHash
             :primary_key => self.class.primary_key
           }.merge(options)
 
-          scope = options[:class_name].constantize
+          scope = options[:class_name].safe_constantize
 
           if scope.respond_to?(:scoped) && options[:conditions]
             scope = scope.scoped(:conditions => options[:conditions])
@@ -174,7 +174,7 @@ module ActiveHash
         field options[:foreign_key].to_sym
 
         define_method(association_id) do
-          options[:class_name].constantize.send("find_by_#{options[:primary_key]}", send(options[:foreign_key]))
+          options[:class_name].safe_constantize.send("find_by_#{options[:primary_key]}", send(options[:foreign_key]))
         end
 
         define_method("#{association_id}=") do |new_value|


### PR DESCRIPTION
In #296, @kbrock pointed out that Rails uses `String#safe_constantize` when finding a `Class` from a class name.

Functionally I think this will be identical, so maybe there's no good reason to make the change other than "following Rails practices as closely as we can".
