### PR TITLE
Support Ruby 3.3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -27,7 +27,7 @@ jobs:
         # | 6.1   |           |          |   2.5   |     |
         # | 7.0   |           |          |   2.7   |     |
         # | 7.1   |           |          |   2.7   |     |
-        ruby: ['3.0', '3.1', '3.2']
+        ruby: ['3.0', '3.1', '3.2', '3.3']
         gemfile: ['gemfiles/rails_6.1.gemfile', 'gemfiles/rails_7.0.gemfile', 'gemfiles/rails_7.1.gemfile']
         include:
         - ruby: '2.4'

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -928,7 +928,7 @@ describe ActiveHash, "Base" do
         it "raises a NoMethodError" do
           expect {
             Country.find_by_name_and_shoe_size("US", 10)
-          }.to raise_error(NoMethodError, /undefined method `find_by_name_and_shoe_size' (?:for|on) Country/)
+          }.to raise_error(NoMethodError, /undefined method `find_by_name_and_shoe_size' (?:for|on) (class )?Country/)
         end
       end
     end
@@ -957,7 +957,7 @@ describe ActiveHash, "Base" do
         it "raises a NoMethodError" do
           expect {
             Country.find_by_name_and_shoe_size!("US", 10)
-          }.to raise_error(NoMethodError, /undefined method `find_by_name_and_shoe_size!' (?:for|on) Country/)
+          }.to raise_error(NoMethodError, /undefined method `find_by_name_and_shoe_size!' (?:for|on) (class )?Country/)
         end
       end
     end
@@ -1181,7 +1181,7 @@ describe ActiveHash, "Base" do
     it "doesn't blow up if you call a missing dynamic finder when fields haven't been set" do
       expect do
         Country.find_by_name("Foo")
-      end.to raise_error(NoMethodError, /undefined method `find_by_name' (?:for|on) Country/)
+      end.to raise_error(NoMethodError, /undefined method `find_by_name' (?:for|on) (class )?Country/)
     end
   end
 


### PR DESCRIPTION
In Ruby 3.3, the message format for [NoMethodError has been changed](https://bugs.ruby-lang.org/issues/18285). I have modified the expected values in the tests to maintain compatibility.

> undefined local variable or method 'privatee' for class Foo (NoMethodError)

## Ruby 3.2.2
```sh
❯ ruby -v
ruby 3.2.2 (2023-03-30 revision e51014f9c0) [x86_64-darwin22]

❯ bundle exec rspec spec/active_hash/base_spec.rb:956
Run options: include {:locations=>{"./spec/active_hash/base_spec.rb"=>[956]}}
.

Finished in 0.00241 seconds (files took 0.317 seconds to load)
1 example, 0 failures
```

## Ruby 3.3.0
```sh
❯ ruby -v
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin23]

❯ bundle exec rspec spec/active_hash/base_spec.rb:956
Run options: include {:locations=>{"./spec/active_hash/base_spec.rb"=>[956]}}
F

Failures:

  1) ActiveHash Base custom finders find_by_<field_one>_and_<field_two>! for fields the class doesn't have raises a NoMethodError
     Failure/Error:
       expect {
         Country.find_by_name_and_shoe_size!("US", 10)
       }.to raise_error(NoMethodError, /undefined method `find_by_name_and_shoe_size!' (?:for|on) Country/)

       expected NoMethodError with message matching /undefined method `find_by_name_and_shoe_size!' (?:for|on) Country/, got #<NoMethodError: undefined method `find_by_name_and_shoe_size!' for class Country> with backtrace:
         # ./lib/active_hash/base.rb:227:in `method_missing'
         # ./spec/active_hash/base_spec.rb:959:in `block (6 levels) in <top (required)>'
         # ./spec/active_hash/base_spec.rb:958:in `block (5 levels) in <top (required)>'
     # ./spec/active_hash/base_spec.rb:958:in `block (5 levels) in <top (required)>'

Finished in 0.01382 seconds (files took 0.38411 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_hash/base_spec.rb:957 # ActiveHash Base custom finders find_by_<field_one>_and_<field_two>! for fields the class doesn't have raises a NoMethodError
```