### PR TITLE
pluck change from array access to using methods.

### DIFF
--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -143,15 +143,10 @@ module ActiveHash
     end
 
     def pluck(*column_names)
-      symbolized_column_names = column_names.map(&:to_sym)
-
-      if symbolized_column_names.length == 1
-        column_name = symbolized_column_names.first
-        all.map { |record| record[column_name] }
+      if column_names.length == 1
+        all.map(&column_names.first.to_sym)
       else
-        all.map do |record|
-          symbolized_column_names.map { |column_name| record[column_name] }
-        end
+        column_names.map { |column_name| all.map(&column_name.to_sym) }.then { |values| :zip.to_proc.(*values) }
       end
     end
 

--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -144,10 +144,10 @@ module ActiveHash
 
     def pluck(*column_names)
       if column_names.length == 1
-        all.map(&column_names.first.to_sym)
+        column_name = column_names.first
+        all.map { |record| record.public_send(column_name) }
       else
-        # `tap with break` can be replaced with yield_self in Ruby 2.5 or then in Ruby 2.6
-        column_names.map { |column_name| all.map(&column_name.to_sym) }.tap { |values| break :zip.to_proc.(*values) }
+        all.map { |record| column_names.map { |column_name| record.public_send(column_name) } }
       end
     end
 

--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -146,7 +146,8 @@ module ActiveHash
       if column_names.length == 1
         all.map(&column_names.first.to_sym)
       else
-        column_names.map { |column_name| all.map(&column_name.to_sym) }.yield_self { |values| :zip.to_proc.(*values) }
+        # `tap with break` can be replaced with yield_self in Ruby 2.5 or then in Ruby 2.6
+        column_names.map { |column_name| all.map(&column_name.to_sym) }.tap { |values| break :zip.to_proc.(*values) }
       end
     end
 

--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -146,7 +146,7 @@ module ActiveHash
       if column_names.length == 1
         all.map(&column_names.first.to_sym)
       else
-        column_names.map { |column_name| all.map(&column_name.to_sym) }.then { |values| :zip.to_proc.(*values) }
+        column_names.map { |column_name| all.map(&column_name.to_sym) }.yield_self { |values| :zip.to_proc.(*values) }
       end
     end
 

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -599,6 +599,30 @@ describe ActiveHash, "Base" do
     it "returns an Array of attribute values" do
       expect(Country.pluck(:id)).to match_array([1, 2, 3])
     end
+
+    context 'with the same field name and method name' do
+      before do
+        class CountryWithContinent < ActiveHash::Base
+          self.data = [
+            {:id => 1, :name => "US", continent: 1},
+            {:id => 2, :name => "Canada", continent: 1},
+            {:id => 3, :name => "Mexico", continent: 1},
+            {:id => 4, :name => "Brazil", continent: 2}
+          ]
+
+          # behave like ActiveRecord Enum
+          CONTINENTS = { north_america: 1, south_america: 2, europe: 3, asia: 4, africa: 5, oceania: 6 }
+
+          def continent
+            CONTINENTS.key(self[:continent]).to_sym
+          end
+        end
+      end
+
+      it "returns the value of the method when the field name is the same as the method name" do
+        expect(CountryWithContinent.pluck(:id, :name, :continent)).to match_array([[1, "US", :north_america], [2, "Canada", :north_america], [3, "Mexico", :north_america], [4, "Brazil", :south_america]])
+      end
+    end
   end
 
   describe '.ids' do
@@ -1278,7 +1302,7 @@ describe ActiveHash, "Base" do
           before do
             Country.field :active, :default => false
           end
-    
+
           it "returns the default value when not present" do
             country = Country.new
             expect(country.attributes[:active]).to eq(false)


### PR DESCRIPTION
Restore ActiveHash::Relation#pluck to execute the specified method on the record.

## Background:

- Through v3.1.x: Executed method names given as symbols.
- In v3.2.x: Change impacted data retrieval by directly referencing `attributes[key]`, affecting compatibility.

https://github.com/active-hash/active_hash/pull/269 broke functionality of gems like `enumerize` which rely on casting values accessed by column names.

## Reproduce

1. Save following file as issue.rb.
2. Please switch version with uncomment line of `gem "active_hash", "3.2.1" # fail test`.
3. Run in terminal `$ ruby issue.rb`

```ruby
#!/usr/bin/env ruby

begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"
  gem 'enumerize'
  # gem "active_hash", "3.1.1" # pass test
  # gem "active_hash", "3.2.1" # fail test
  gem "active_hash", github: "active-hash/active_hash", ref: "6c51fa6d" # == master # fail test
  # gem "active_hash", github: "iberianpig/active_hash", branch: "fix/revert-pluck-behavior" # pass test
end

require "active_hash"
require "minitest/autorun"
require "logger"

class Country < ActiveHash::Base
  extend Enumerize
  enumerize :continent, in: { north_america: 1, south_america: 2, europe: 3, asia: 4, africa: 5, oceania: 6 }
  self.data = [
      {
        "id": 1,
        "name": "US",
        "custom_field_1": 1,
        "continent": 1
      },
      {
        "id": 2,
        "name": "Canada",
        "custom_field_2": 2,
        "continent": 1
      }
    ]
end
class BugTest < Minitest::Test
  def test_pluck_with_enumerize
    assert_equal "north_america", Country.find(1).continent  # continent is enumerized
    assert_equal [["US", "north_america"], ["Canada", "north_america"]], Country.all.pluck(:name, :continent)
  end
end
```
### 3.1.1
```
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Run options: --seed 37444

# Running:

.

Finished in 0.000997s, 1002.6591 runs/s, 2005.3181 assertions/s.

1 runs, 2 assertions, 0 failures, 0 errors, 0 skips
```

### 3.2.1
```diff
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Run options: --seed 14751

# Running:

F

Finished in 0.004705s, 212.5528 runs/s, 425.1055 assertions/s.

  1) Failure:
BugTest#test_pluck_with_enumerize [issue.rb:43]:
--- expected
+++ actual
@@ -1 +1 @@
-[["US", "north_america"], ["Canada", "north_america"]]
+[["US", 1], ["Canada", 1]]


1 runs, 2 assertions, 1 failures, 0 errors, 0 skips

```