### PR TITLE
fix: rails 7.1.3 support requires a has_query_constraints? method

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -127,6 +127,10 @@ module ActiveHash
         @record_index ||= {}
       end
 
+      def has_query_constraints?
+        false
+      end
+
       private :record_index
 
       def reset_record_index


### PR DESCRIPTION
**Problem being solved**

Tests are failing with Rails 7.1.3.

I think the significant change upstream was rails/rails@59e72b0b