### PR TITLE
ci: allow manual dispatch, run once a week to integration test

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -3,6 +3,9 @@ concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
   cancel-in-progress: true
 on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * 3" # At 08:00 on Wednesday # https://crontab.guru/#0_8_*_*_3
   push:
     branches:
       - master


### PR DESCRIPTION
**Problem being solved**

Two improvements to CI:

- regularly run CI once a week
- allow manual running of the test suite against an arbitrary branch

This should help us detect when a Rails release has broken Active Hash (see #300 for example).
