### PR TITLE
test: pin sqlite3 dependency to `< 2.0`

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,6 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         # | rails | rails EOL | ruby EOL | min ruby| max |
         # | ----- | ---------+| --------+| --------|---- |

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem 'sqlite3', '~> 1.4.0'
+  gem 'sqlite3', '~> 1.4', '< 2.0' # can allow 2.0 once Rails's sqlite adapter allows it
 end
 
 gem 'activerecord', '>= 5.0.0'

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -11,7 +11,7 @@ platform :jruby do
 end
 
 platform :ruby do
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.4', '< 2.0' # can allow 2.0 once Rails's sqlite adapter allows it
 end
 
 gemspec :path => '../'

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -11,7 +11,7 @@ platform :jruby do
 end
 
 platform :ruby do
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.4', '< 2.0' # can allow 2.0 once Rails's sqlite adapter allows it
 end
 
 gemspec :path => '../'

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -11,7 +11,7 @@ platform :jruby do
 end
 
 platform :ruby do
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.4', '< 2.0' # can allow 2.0 once Rails's sqlite adapter allows it
 end
 
 gemspec :path => '../'

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -11,7 +11,7 @@ platform :jruby do
 end
 
 platform :ruby do
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.4', '< 2.0' # can allow 2.0 once Rails's sqlite adapter allows it
 end
 
 gemspec :path => '../'


### PR DESCRIPTION
Because Rails's sqlite adapter requires sqlite3 `~> 1.4` through v7.1.3.2, tests started failing once the new sqlite3 v2.0 was pulled in:

https://github.com/active-hash/active_hash/actions/runs/8813099625

This has been fixed in Rails `7-1-stable` and `main` but no releases are yet available.

This PR:

- pins the test dependency to `< 2.0` for the relevant Rails versions
- and also sets `fail-fast: false` in the github actions pipeline matrix
