### PR TITLE
Fix arguments of has_many method

### DIFF
--- a/lib/associations/associations.rb
+++ b/lib/associations/associations.rb
@@ -6,7 +6,7 @@ module ActiveHash
         require_relative 'reflection_extensions'
       end
 
-      def has_many(association_id, **options)
+      def has_many(association_id, scope = nil, **options, &extension)
         if options[:through]
           klass_name = association_id.to_s.classify
           klass =


### PR DESCRIPTION
## Problem being solved

fix this issue. https://github.com/active-hash/active_hash/issues/305

I think that merging this PR will eliminate the error that is occurring in the above issue.

## Investigation

ActiveHash supports up to Rails ver5.0.
I checked Rails ver5.0 to Rails ver7.1
Then I found that the argument structure of the has_many method is almost the same.

- [Where has_many is defined in Rails v7.0](https://github.com/rails/rails/blob/v7.0.8.1/activerecord/lib/active_record/associations.rb#L1469)
- [Where has_many is defined in Rails v6.1](https://github.com/rails/rails/blob/v6.1.7.7/activerecord/lib/active_record/associations.rb#L1457)
- [Where has_many is defined in Rails v6.0](https://github.com/rails/rails/blob/v6.0.6.1/activerecord/lib/active_record/associations.rb#L1370)
- [Where has_many is defined in Rails v5.2](https://github.com/rails/rails/blob/v5.2.8.1/activerecord/lib/active_record/associations.rb#L1368)
- [Where has_many is defined in Rails v5.1](https://github.com/rails/rails/blob/v5.1.7/activerecord/lib/active_record/associations.rb#L1401)
- [Where has_many is defined in Rails v5.0](https://github.com/rails/rails/blob/v5.0.7.2/activerecord/lib/active_record/associations.rb#L1370)

Hence, I modified it to pass the same arguments as ActiveRecord#has_many.