### PR TITLE
Add column names method

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -51,7 +51,7 @@ module ActiveHash
       end
 
       def column_names
-        @column_names ||= field_names.map(&:to_s)
+        @column_names ||= field_names.map(&:name)
       end
 
       def the_meta_class

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -64,7 +64,9 @@ module ActiveHash
       #  # => ["id", "name", "code"]
       #
       def column_names
-        field_names.map(&:name)
+        field_names.map do |field|
+          field.respond_to?(:name) ? field.name : field.to_s.freeze
+        end
       end
 
       def the_meta_class

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -64,9 +64,7 @@ module ActiveHash
       #  # => ["id", "name", "code"]
       #
       def column_names
-        field_names.map do |field|
-          field.respond_to?(:name) ? field.name : field.to_s.freeze
-        end
+        field_names.map(&:name)
       end
 
       def the_meta_class

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -50,6 +50,10 @@ module ActiveHash
         @field_names ||= []
       end
 
+      def column_names
+        @column_names ||= field_names.map(&:to_s)
+      end
+
       def the_meta_class
         class << self
           self

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -64,7 +64,7 @@ module ActiveHash
       #  # => ["id", "name", "code"]
       #
       def column_names
-        @column_names ||= field_names.map(&:name)
+        field_names.map(&:name)
       end
 
       def the_meta_class

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -50,6 +50,19 @@ module ActiveHash
         @field_names ||= []
       end
 
+      #
+      # Useful for CSV integration needing column names as strings.
+      #
+      # @return [Array<String>] An array of column names as strings.
+      #
+      # @example Usage
+      #  class Country < ActiveHash::Base
+      #    fields :name, :code
+      #  end
+      #
+      #  Country.column_names
+      #  # => ["id", "name", "code"]
+      #
       def column_names
         @column_names ||= field_names.map(&:name)
       end

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -116,6 +116,16 @@ describe ActiveHash, "Base" do
     end
   end
 
+  describe ".column_names" do
+    before do
+      Country.fields :name, :iso_name, "size"
+    end
+
+    it "returns an array of column names" do
+      expect(Country.column_names).to eq(["name", "iso_name", "size"])
+    end
+  end
+
   describe ".data=" do
     before do
       class Region < ActiveHash::Base

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -122,6 +122,7 @@ describe ActiveHash, "Base" do
     end
 
     it "returns an array of column names" do
+      skip "Not supported in Ruby 3.0.0" if RUBY_VERSION < "3.0.0"
       expect(Country.column_names).to eq(["name", "iso_name", "size"])
     end
   end

--- a/spec/active_yaml/aliases_spec.rb
+++ b/spec/active_yaml/aliases_spec.rb
@@ -45,6 +45,7 @@ describe ActiveYaml::Aliases do
       end
 
       it 'excludes them from column_names' do
+        skip "Not supported in Ruby 3.0.0" if RUBY_VERSION < "3.0.0"
         model.all
         expect(model.column_names).to match_array ["name", "flavor", "price"]
       end
@@ -77,6 +78,7 @@ describe ActiveYaml::Aliases do
       end
 
       it 'excludes them from column_names' do
+        skip "Not supported in Ruby 3.0.0" if RUBY_VERSION < "3.0.0"
         model.all
         expect(model.column_names).to match_array ["name", "flavor", "price", "slogan", "key"]
       end

--- a/spec/active_yaml/aliases_spec.rb
+++ b/spec/active_yaml/aliases_spec.rb
@@ -43,6 +43,11 @@ describe ActiveYaml::Aliases do
         model.all
         expect(model.field_names).to match_array [:name, :flavor, :price]
       end
+
+      it 'excludes them from column_names' do
+        model.all
+        expect(model.column_names).to match_array ["name", "flavor", "price"]
+      end
     end
   end
 
@@ -69,6 +74,11 @@ describe ActiveYaml::Aliases do
       it 'excludes them from fields' do
         model.all
         expect(model.field_names).to match_array [:name, :flavor, :price, :slogan, :key]
+      end
+
+      it 'excludes them from column_names' do
+        model.all
+        expect(model.column_names).to match_array ["name", "flavor", "price", "slogan", "key"]
       end
     end
   end


### PR DESCRIPTION
This pull request adds the column_names method to the ActiveHash gem. 

The column_names method is analogous to the one found in Rails' ActiveRecord, allowing users to retrieve the names of columns defined in an ActiveHash model. 

Added column_names method to ActiveHash::Base class.
The method returns an array of string column names, similar to ActiveRecord's column_names method.

```ruby
Country.column_names
# => ["id", "name", "code"]
```

close #310