### PR TITLE
fix: ensure the stored field names are always symbols

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -198,7 +198,9 @@ module ActiveHash
       end
 
       def field(field_name, options = {})
+        field_name = field_name.to_sym
         validate_field(field_name)
+
         field_names << field_name
 
         add_default_value(field_name, options[:default]) if options.key?(:default)
@@ -210,7 +212,8 @@ module ActiveHash
       end
 
       def validate_field(field_name)
-        if [:attributes].include?(field_name.to_sym)
+        field_name = field_name.to_sym
+        if [:attributes].include?(field_name)
           raise ReservedFieldError.new("#{field_name} is a reserved field in ActiveHash.  Please use another name.")
         end
       end
@@ -264,7 +267,7 @@ module ActiveHash
       end
 
       def define_getter_method(field, default_value)
-        unless instance_methods.include?(field.to_sym)
+        unless instance_methods.include?(field)
           define_method(field) do
             attributes[field].nil? ? default_value : attributes[field]
           end

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -106,6 +106,16 @@ describe ActiveHash, "Base" do
     end
   end
 
+  describe ".field_names" do
+    before do
+      Country.fields :name, :iso_name, "size"
+    end
+
+    it "returns an array of field names" do
+      expect(Country.field_names).to eq([:name, :iso_name, :size])
+    end
+  end
+
   describe ".data=" do
     before do
       class Region < ActiveHash::Base


### PR DESCRIPTION
There is code that assumes that `@field_names` will contain symbols, like this method in ActiveHash::Base:

    def respond_to?(method_name, include_private=false)
      super ||
        begin
          config = configuration_for_custom_finder(method_name)
          config && config[:fields].all? do |field|
            field_names.include?(field.to_sym) || field.to_sym == :id
          end
        end
    end


This also introduces an explicit test for `#field_names`.