### PR TITLE
Ensure field_names contains only symbols

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -198,6 +198,7 @@ module ActiveHash
       end
 
       def field(field_name, options = {})
+        field_name = field_name.to_sym
         validate_field(field_name)
         field_names << field_name
 
@@ -210,7 +211,7 @@ module ActiveHash
       end
 
       def validate_field(field_name)
-        if [:attributes].include?(field_name.to_sym)
+        if [:attributes].include?(field_name)
           raise ReservedFieldError.new("#{field_name} is a reserved field in ActiveHash.  Please use another name.")
         end
       end
@@ -222,7 +223,7 @@ module ActiveHash
           begin
             config = configuration_for_custom_finder(method_name)
             config && config[:fields].all? do |field|
-              field_names.include?(field.to_sym) || field.to_sym == :id
+              field_names.include?(field) || field == :id
             end
           end
       end
@@ -251,7 +252,7 @@ module ActiveHash
           {
             :all? => !!$1,
             :bang? => !!$3,
-            :fields => $2.split('_and_')
+            :fields => $2.split('_and_').map(&:to_sym)
           }
         end
       end
@@ -260,11 +261,11 @@ module ActiveHash
 
       def add_default_value field_name, default_value
         self.default_attributes ||= {}
-        self.default_attributes[field_name] = default_value
+        self.default_attributes[field_name.to_sym] = default_value
       end
 
       def define_getter_method(field, default_value)
-        unless instance_methods.include?(field.to_sym)
+        unless instance_methods.include?(field)
           define_method(field) do
             attributes[field].nil? ? default_value : attributes[field]
           end

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -39,6 +39,10 @@ describe ActiveHash, "Base" do
       Country.fields :name, :iso_name
     end
 
+    it "registers field_names" do
+      expect(Country.field_names).to eq([:name, :iso_name])
+    end
+
     it "defines a reader for each field" do
       expect(Country.new).to respond_to(:name)
       expect(Country.new).to respond_to(:iso_name)
@@ -103,6 +107,16 @@ describe ActiveHash, "Base" do
       expect do
         Country.field :attributes
       end.to raise_error(ActiveHash::ReservedFieldError)
+    end
+  end
+
+  describe ".fields (string)" do
+    before do
+      Country.fields "name", "iso_name"
+    end
+
+    it "registers field_names" do
+      expect(Country.field_names).to eq([:name, :iso_name])
     end
   end
 


### PR DESCRIPTION

All public methods that take a field name will convert it to a symbol.
All internal methods can assume that field_name is a symbol

In response to a bug that was uncovered in #311 (test is red-green)