### PR TITLE
Make Default field private

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -266,6 +266,8 @@ module ActiveHash
         self.default_attributes[field_name] = default_value
       end
 
+      private :add_default_value
+
       def define_getter_method(field, default_value)
         unless instance_methods.include?(field)
           define_method(field) do


### PR DESCRIPTION
Followup to #312 

I noticed that this is public.

We either want to make this `private
Or we want to `to_sym` the field name.

I went with the first, but just say if you would rather make it `public` and I can add a `to_sym` instead.