### PR TITLE
Add support for a block argument on `Relation#count`

### DIFF
--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -135,6 +135,7 @@ module ActiveHash
     end
 
     def count
+      return super if block_given?
       length
     end
 

--- a/spec/active_hash/relation_spec.rb
+++ b/spec/active_hash/relation_spec.rb
@@ -39,6 +39,16 @@ RSpec.describe ActiveHash::Relation do
     end
   end
 
+  describe '#count' do
+    it 'supports a block arg' do
+      expect(subject.count { |s| s.name == "US" }).to eq(1)
+    end
+
+    it 'returns the correct number of items of the relation' do
+      expect(subject.count).to eq(2)
+    end
+  end
+
   describe '#size' do
     it 'returns an Integer' do
       expect(subject.size).to be_an(Integer)


### PR DESCRIPTION
Closes #316 

This pull request adds support for a block argument in the `#count` method.