### PR TITLE
Fix the behavior when passing nil to `exists?`

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -102,12 +102,12 @@ module ActiveHash
         end
       end
 
-      def exists?(args = nil)
+      def exists?(args = :none)
         if args.respond_to?(:id)
           record_index[args.id.to_s].present?
-        elsif args == false
+        elsif !args
           false
-        elsif args.nil?
+        elsif args == :none
           all.present?
         elsif args.is_a?(Hash)
           all.where(args).present?

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -1169,6 +1169,12 @@ describe ActiveHash, "Base" do
       end
     end
 
+    context "when nil is passed" do
+      it "return nil" do
+        expect(Country.exists?(nil)).to be_falsy
+      end
+    end
+
     describe "with matches" do
       context 'for a record argument' do
         it "return true" do


### PR DESCRIPTION
Currently, the behavior when passing `nil` to `exists?` doesn't match with Rails's behavior. Rails always returns `false`, but ActiveHash not. https://github.com/rails/rails/blob/5a0b2fa5a3be6ffd49fa7f1c3544c1da403c9cb5/activerecord/lib/active_record/relation/finder_methods.rb#L367

This PR changes the behavior to match with Rails's.