### PR TITLE
Fix an example for resetting the state every request

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ Call `Model.reload(true)` to force reload the data from disk.
 In Rails, you can use this snippet. Please just note it resets the state every request, which may not always be desired.
 
 ```ruby
-before_filter do
+before_action do
   [Model1, Model2, Model3].each { |m| m.reload(true) }
 end
 ```


### PR DESCRIPTION
`before_filter` was removed by Rails v5.1.0.