### PR TITLE
Update CI with Ruby 3.4, fix Rails Logger constant resolution issue

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,14 +22,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # | rails | rails EOL | minruby |
-        # |-------+-----------+---------+
-        # | 6.1   |  10/2024  |   2.5   |
-        # | 7.0   |   4/2025  |   2.7   |
-        # | 7.1   |  10/2025  |   2.7   |
-        # | 7.2   |   8/2026  |   3.1   |
-        # | 8.0   | ~11/2026  |   3.2   |
-        ruby: ['3.0', '3.1', '3.2', '3.3']
+        # | rails | rails EOL | minruby | maxruby |
+        # |-------+-----------+---------+---------+
+        # | 6.1   |  10/2024  |   2.5   | 3.3     |
+        # | 7.0   |   4/2025  |   2.7   | 3.3     |
+        # | 7.1   |  10/2025  |   2.7   |         |
+        # | 7.2   |   8/2026  |   3.1   |         |
+        # | 8.0   | ~11/2026  |   3.2   |         |
+        ruby: ['3.0', '3.1', '3.2', '3.3', '3.4']
         gemfile:
           - 'gemfiles/rails_6.1.gemfile'
           - 'gemfiles/rails_7.0.gemfile'
@@ -43,6 +43,10 @@ jobs:
           gemfile: 'gemfiles/rails_8.0.gemfile'
         - ruby: '3.1'
           gemfile: 'gemfiles/rails_8.0.gemfile'
+        - ruby: '3.4'
+          gemfile: 'gemfiles/rails_6.1.gemfile'
+        - ruby: '3.4'
+          gemfile: 'gemfiles/rails_7.0.gemfile'
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     name: Ruby ${{ matrix.ruby }}, ${{ matrix.gemfile }}

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -5,6 +5,7 @@ gem 'rspec', '~> 3.9'
 gem 'rake', '~> 13.0'
 gem 'json'
 gem 'test-unit'
+gem 'concurrent-ruby', '< 1.3.5' # to avoid problem described in https://github.com/rails/rails/pull/54264
 
 platform :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.6'

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -5,6 +5,7 @@ gem 'rspec', '~> 3.9'
 gem 'rake', '~> 13.0'
 gem 'json'
 gem 'test-unit'
+gem 'concurrent-ruby', '< 1.3.5' # to avoid problem described in https://github.com/rails/rails/pull/54264
 
 platform :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.6'

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -973,7 +973,7 @@ describe ActiveHash, "Base" do
         it "raises a NoMethodError" do
           expect {
             Country.find_by_name_and_shoe_size("US", 10)
-          }.to raise_error(NoMethodError, /undefined method `find_by_name_and_shoe_size' (?:for|on) (class )?Country/)
+          }.to raise_error(NoMethodError, /undefined method [`']find_by_name_and_shoe_size' (?:for|on) (class )?Country/)
         end
       end
     end
@@ -1002,7 +1002,7 @@ describe ActiveHash, "Base" do
         it "raises a NoMethodError" do
           expect {
             Country.find_by_name_and_shoe_size!("US", 10)
-          }.to raise_error(NoMethodError, /undefined method `find_by_name_and_shoe_size!' (?:for|on) (class )?Country/)
+          }.to raise_error(NoMethodError, /undefined method [`']find_by_name_and_shoe_size!' (?:for|on) (class )?Country/)
         end
       end
     end
@@ -1232,7 +1232,7 @@ describe ActiveHash, "Base" do
     it "doesn't blow up if you call a missing dynamic finder when fields haven't been set" do
       expect do
         Country.find_by_name("Foo")
-      end.to raise_error(NoMethodError, /undefined method `find_by_name' (?:for|on) (class )?Country/)
+      end.to raise_error(NoMethodError, /undefined method [`']find_by_name' (?:for|on) (class )?Country/)
     end
   end
 


### PR DESCRIPTION
1. Fix missing Logger constant because the latest concurrent-ruby dropped logger as a dependency, this broke Rails's dependencies.
    - See https://github.com/active-hash/active_hash/actions/runs/12903718390/job/35979486630 for an example failure.
    - See https://github.com/rails/rails/pull/54264 for more details.
3. Add Ruby 3.4 to the CI matrix (but exclude Rails 6.0 and 7.1 because of unbundled gem errors with bigdecimal, base64, etc.).
