### PR TITLE
Has many through supports aliased names

### DIFF
--- a/lib/associations/associations.rb
+++ b/lib/associations/associations.rb
@@ -8,16 +8,16 @@ module ActiveHash
 
       def has_many(association_id, scope = nil, **options, &extension)
         if options[:through]
-          active_hash_source_association_name = options[:source]&.to_s || association_id.to_s.singularize
+          source_association_name = options[:source]&.to_s || association_id.to_s.singularize
 
           through_klass = reflect_on_association(options[:through])&.klass
-          klass = through_klass&.reflect_on_association(active_hash_source_association_name)&.klass
+          klass = through_klass&.reflect_on_association(source_association_name)&.klass
 
           if klass && klass < ActiveHash::Base
             define_method(association_id) do
               join_models = send(options[:through])
               join_models.flat_map do |join_model|
-                join_model.send(active_hash_source_association_name)
+                join_model.send(source_association_name)
               end.uniq
             end
 

--- a/lib/associations/associations.rb
+++ b/lib/associations/associations.rb
@@ -8,14 +8,16 @@ module ActiveHash
 
       def has_many(association_id, scope = nil, **options, &extension)
         if options[:through]
-          klass_name = association_id.to_s.classify
-          klass = klass_name.safe_constantize
+          active_hash_source_association_name = options[:source]&.to_s || association_id.to_s.singularize
+
+          through_klass = reflect_on_association(options[:through])&.klass
+          klass = through_klass&.reflect_on_association(active_hash_source_association_name)&.klass
 
           if klass && klass < ActiveHash::Base
             define_method(association_id) do
               join_models = send(options[:through])
               join_models.flat_map do |join_model|
-                join_model.send(association_id.to_s.singularize)
+                join_model.send(active_hash_source_association_name)
               end.uniq
             end
 

--- a/spec/associations/active_record_extensions_spec.rb
+++ b/spec/associations/active_record_extensions_spec.rb
@@ -236,9 +236,17 @@ unless SKIP_ACTIVE_RECORD
         end
 
         describe "with the :source option" do
-          it "finds ActiveHash records through the join model" do
+          before do
+            # NOTE: Removing the Patient#physicians association and adding Patient#doctors
+            Patient._reflections.delete('physicians')
+            Patient.class_eval do
+              define_method(:physicians) { raise NoMethodError, "The #physicians association is removed in this spec, use #doctors" }
+              define_method(:physicians=) { |_| raise NoMethodError, "The #physicians association is removed in this spec, use #doctors" }
+            end
             Patient.has_many :doctors, through: :appointments, source: :physician
+          end
 
+          it "finds ActiveHash records through the join model" do
             patient = Patient.create!
 
             physician = Physician.last
@@ -249,10 +257,25 @@ unless SKIP_ACTIVE_RECORD
         end
 
         describe ":through when the join model uses an aliased association" do
-          it "finds ActiveHash records through the join model" do
+          before do
+            # NOTE: Removing the Appointment#physician association and adding Appointment#doctor
+            Appointment._reflections.delete('physician')
+            Appointment.class_eval do
+              define_method(:physician) { raise NoMethodError, "The #physician association is removed in this spec, use #doctor" }
+              define_method(:physician=) { |_| raise NoMethodError, "The #physician association is removed in this spec, use #doctor" }
+            end
             Appointment.belongs_to :doctor, class_name: 'Physician', foreign_key: :physician_id
-            Patient.has_many :doctors, through: :appointments
 
+            # NOTE: Removing the Patient#physicians association and adding Patient#doctors
+            Patient._reflections.delete('physicians')
+            Patient.class_eval do
+              define_method(:physicians) { raise NoMethodError, "The #physicians association is removed in this spec, use #doctors" }
+              define_method(:physicians=) { |_| raise NoMethodError, "The #physicians association is removed in this spec, use #doctors" }
+            end
+            Patient.has_many :doctors, through: :appointments
+          end
+
+          it "finds ActiveHash records through the join model" do
             patient = Patient.create!
 
             physician = Physician.last


### PR DESCRIPTION
### Bug/Problem

Currently, using a `has_many :through` to return a collection of ActiveHash records is limited to working successfully in the case where the `association_id` passed to `has_many` exactly corresponds to the ActiveHash class name. It must be the pluralized version of the singularized class name.

In this example, `Zoo#countries` works as expected:
```rb
class Country < ActiveHash::Base
  # ...
end

class Animal < ApplicationRecord
  extend ActiveHash::Associations::ActiveRecordExtensions
  
  belongs_to :country
  belongs_to :zoo
end

class Zoo < ApplicationRecord
  extend ActiveHash::Associations::ActiveRecordExtensions

  has_many :animals
  has_many :countries, through: :animals
end
```

But, If any of the association method names involved in the `has_many through:` require some type of aliasing where the relationship to the ActiveHash class can't be deduced, the behavior in `ActiveHash::Associations::ActiveRecordExtensions` will not correctly define the ActiveHash version of the association reader method.

Here, `Zoo#nations` would break
```rb
class Zoo < ApplicationRecord
  extend ActiveHash::Associations::ActiveRecordExtensions

  has_many :animals
  has_many :nations, through: :animals, source: :country
end
```

And here, `Zoo#countries` would break
```rb
class Animal < ApplicationRecord
  extend ActiveHash::Associations::ActiveRecordExtensions
  
  belongs_to :country_of_origin, class_name: 'Country'
  belongs_to :zoo
end

class Zoo < ApplicationRecord
  extend ActiveHash::Associations::ActiveRecordExtensions

  has_many :animals
  has_many :countries, through: :animals
end
```

It felt worth supporting these cases because it feels similar to how [the `class_name` option is correctly supported in a `belongs_to_active_hash`](https://github.com/active-hash/active_hash/blob/master/lib/associations/associations.rb#L43) for equivalent use cases around aliased association names.

I made sure the use of `source` matches how that option is passed [in ActiveRecord itself](https://apidock.com/rails/ActiveRecord/Associations/ClassMethods/has_many#:~:text=%3Asource,source%20is%20given.) (`has_many throughs:` use `source`, and don't support `class_name`).

### Documentation

I looked for a place to document this new behavior in the README, but there wasn't an obvious place to add this without adding a whole new section or something like that. I can try to do so if that feels appropriate.

### Specs
I added specs for the new supported cases. To reuse the same spec setup and ephemeral classes, but at the same time to be able to change the association definitions per spec context, I parameterized the `define_doctor_classes` spec setup method. This adds some complexity in a way I don't love, but still felt better than alternate approaches. I'm game to rethink this, though, if it doesn't feel like the right solution.