### PR TITLE
Fix `model_name` availability by explicitly extending ActiveModel::Naming

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -24,6 +24,7 @@ module ActiveHash
     class_attribute :_data, :dirty, :default_attributes, :scopes
 
     if Object.const_defined?(:ActiveModel)
+      extend ActiveModel::Naming
       extend ActiveModel::Translation
       include ActiveModel::Conversion
     else


### PR DESCRIPTION
In v4.0.0, switching from `extend ActiveModel::Naming` to only `extend ActiveModel::Translation` (ref: https://github.com/active-hash/active_hash/pull/230) can cause "undefined method 'model_name'" errors when ActiveHash models include `ActiveModel::Serialization`, particularly with Rails 8.0+; actually I encountered this problem in our project.

While `ActiveModel::Translation` includes `ActiveModel::Naming` internally, the inclusion doesn't always properly expose the `model_name` class method when extended. This breaks compatibility for models that depend on `model_name` being available at the class level.

This commit explicitly extends both `ActiveModel::Naming` and `ActiveModel::Translation` to ensure model_name is always available while maintaining i18n support. This approach ensures compatibility across all Rails versions.